### PR TITLE
csv-output: reusable StringBuilder, flush only on close

### DIFF
--- a/roadrunner-csv-output/src/main/java/io/roadrunner/output/csv/CsvOutputEventListener.java
+++ b/roadrunner-csv-output/src/main/java/io/roadrunner/output/csv/CsvOutputEventListener.java
@@ -33,7 +33,10 @@ public class CsvOutputEventListener implements EventListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(CsvOutputEventListener.class);
 
+    private static final int ROW_BUFFER_SIZE = 128;
+
     private final Path csvOutputFile;
+    private final StringBuilder rowBuilder = new StringBuilder(ROW_BUFFER_SIZE);
     private BufferedWriter bufferedWriter;
 
     public CsvOutputEventListener(Path csvOutputFile) {
@@ -54,18 +57,17 @@ public class CsvOutputEventListener implements EventListener {
     @Override
     public void onEvent(Collection<? extends Event> batch) {
         for (var response : batch) {
-            var row =
-                    switch (response) {
-                        case SamplerResponse.Error e -> toRow(e, "KO");
-                        case SamplerResponse.Response<?> e -> toRow(e, "OK");
-                        case UserEvent.Enter e -> "USER,%d,ENTER".formatted(e.timestamp());
-                        case UserEvent.Exit e -> "USER,%d,EXIT".formatted(e.timestamp());
-                        default -> throw new IllegalStateException("Unexpected value: " + response);
-                    };
+            rowBuilder.setLength(0);
+            switch (response) {
+                case SamplerResponse.Error e -> appendResponseRow(e, "KO");
+                case SamplerResponse.Response<?> e -> appendResponseRow(e, "OK");
+                case UserEvent.Enter e -> rowBuilder.append("USER,").append(e.timestamp()).append(",ENTER");
+                case UserEvent.Exit e -> rowBuilder.append("USER,").append(e.timestamp()).append(",EXIT");
+                default -> throw new IllegalStateException("Unexpected value: " + response);
+            }
             try {
-                bufferedWriter.write(row);
+                bufferedWriter.append(rowBuilder);
                 bufferedWriter.newLine();
-                bufferedWriter.flush();
             } catch (IOException e) {
                 LOG.error("cannot write csv output", e);
                 throw new RuntimeException(e);
@@ -73,19 +75,24 @@ public class CsvOutputEventListener implements EventListener {
         }
     }
 
-    private String toRow(SamplerResponse<?> response, String status) {
-        return "REQ,%d,%d,%d,%d,%s"
-                .formatted(
-                        response.scheduledStartTime(),
-                        response.timestamp(),
-                        response.stopTime(),
-                        response.latency(),
-                        status);
+    private void appendResponseRow(SamplerResponse<?> response, String status) {
+        rowBuilder
+                .append("REQ,")
+                .append(response.scheduledStartTime())
+                .append(',')
+                .append(response.timestamp())
+                .append(',')
+                .append(response.stopTime())
+                .append(',')
+                .append(response.latency())
+                .append(',')
+                .append(status);
     }
 
     @Override
     public void onStop() {
         try {
+            bufferedWriter.flush();
             bufferedWriter.close();
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
## Summary
- Drops `String.format` / `.formatted` from `CsvOutputEventListener.onEvent` in favor of a reusable `StringBuilder` (preallocated 128 chars) — eliminates per-row `Formatter`, `FormatSpecifier` list, `Long` boxing, and intermediate `StringBuilder` growth.
- Moves `BufferedWriter.flush()` out of `onEvent` and into `onStop` so the buffer actually buffers between rows.
- Output format and `CsvOutputEventReader` round-trip are unchanged.

## Why
JFR profile of `openWorldBenchmark @ arrivalRate=10000` (virtual-thread open-world load test) showed `CsvOutputEventListener.onEvent` dominated both CPU and allocation on the single journal-consumer thread:
- **17.9% of CPU samples** on `BufferedWriter.flush → FileChannelImpl.write → NativeThreadSet.add → NativeThread.current0` — every row was a tiny (~40 B) syscall.
- **Allocations**: 122 MB `Formatter$FixedString`, 84 MB `Formatter$FormatSpecifier`, plus hundreds of samples on `Formatter.parse`, `Long.valueOf`, `ArrayList.grow` and `StringBuilder.append.copyOf` per row.

This is the single-consumer choke point at 10 k rps; the request side scales freely on virtual threads (each request is just `Thread.sleep(100ms)`).

## Test plan
- [x] `mvn -pl roadrunner-csv-output -am clean test` on JDK 25 — compiles, no test failures (module has no unit tests, but the surrounding reactor builds).
- [ ] Re-run `openWorldBenchmark-Throughput-arrivalRate-10000` and capture a fresh JFR; verify `CsvOutputEventListener.onEvent` no longer appears in the top CPU or top allocators.
- [ ] Run a benchmark with a non-empty CSV output and verify `CsvOutputEventReader` parses it (round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)