### PR TITLE
Fix JReleaser deprecation warnings in build

### DIFF
--- a/docs/superpowers/plans/2026-07-13-sampler-method-extension-points.md
+++ b/docs/superpowers/plans/2026-07-13-sampler-method-extension-points.md
@@ -1,0 +1,1216 @@
+# Sampler Method Extension Points Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a sampler class expose multiple named, type-checked operations (instead of one fixed `execute()`), selected and literal-bound from a small CLI expression (`query("SELECT ...")`), while every existing sampler and downstream engine code keeps working unchanged.
+
+**Architecture:** Two new types in `roadrunner-samplers-spi` — `SamplerExpression` (hand-rolled parser: `name("lit", ...)` → method name + literal args) and `SamplerExtensionPoint` (validates a target object's `Sampler`-returning methods, binds literal args via `MethodHandles.publicLookup()`, returns a `Supplier<Sampler>`). JDBC and Neo4j samplers migrate onto this: their per-call logic moves into a new `JDBCSampler`/`Neo4jSampler` "methods class" exposing `query(String sql)`; their `SamplerProvider`s become thin wrappers delegating to the bound `Supplier<Sampler>`. AB and VM are untouched, proving the old direct-`Sampler`-implementation style still works.
+
+**Tech Stack:** Java 25, Maven (multi-module, JPMS), JUnit 5 + AssertJ, JMH (`roadrunner-microbenchmarks`), `java.lang.invoke.MethodHandle`s (JDK stdlib, no new dependency).
+
+**Spec:** `docs/superpowers/specs/2026-07-13-sampler-method-extension-points-design.md`
+
+## Global Constraints
+
+- No new Maven module. Both new types live in `roadrunner-samplers-spi`.
+- No new external dependency (no parser generator, no extra reflection library).
+- Literal CLI arguments support only `String` in this change — no numeric/`URL`/file-content literals.
+- Binding uses `MethodHandles.publicLookup()`, never `MethodHandles.lookup()` — `roadrunner-samplers-spi` must not gain a `requires` edge onto sampler modules.
+- `SamplerExtensionPoint` validation only inspects methods whose return type is exactly `Sampler`; methods with any other return type are ignored, not rejected.
+- AB and VM samplers are not touched by this plan.
+- Every new/modified `.java` file gets the existing Apache-2.0 header (copy verbatim from any existing file in the same module) and must pass `./mvnw spotless:apply -pl <module>` (Palantir Java format) before committing.
+- Use `./mvnw` (wrapper) for all build/test commands below, run from the repo root.
+
+---
+
+### Task 1: `SamplerExpression` parser
+
+**Files:**
+- Modify: `roadrunner-samplers-spi/pom.xml`
+- Create: `roadrunner-samplers-spi/src/main/java/io/roadrunner/samplers/spi/SamplerExpression.java`
+- Test: `roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/SamplerExpressionTest.java`
+
+**Interfaces:**
+- Produces: `record SamplerExpression(String methodName, List<String> arguments)` with `static SamplerExpression parse(String input)`, throwing `IllegalArgumentException` on malformed input. Package `io.roadrunner.samplers.spi`. Consumed by Task 2 and by `JDBCSamplerPlugin`/`Neo4jSamplerPlugin` in Tasks 3–4.
+
+- [ ] **Step 1: Add test dependencies to `roadrunner-samplers-spi/pom.xml`**
+
+No test source set exists yet in this module. Add the same test dependencies every sibling module uses (versions come from the parent's `dependencyManagement` — do not add explicit `<version>`):
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>io.roadrunner</groupId>
+        <artifactId>roadrunner-api</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/SamplerExpressionTest.java`:
+
+```java
+/**
+ * Copyright 2024 Symentis.pl
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.roadrunner.samplers.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SamplerExpressionTest {
+
+    static Stream<Arguments> validExpressions() {
+        return Stream.of(
+                Arguments.of("query(\"SELECT 1\")", "query", List.of("SELECT 1")),
+                Arguments.of("noArgs()", "noArgs", List.of()),
+                Arguments.of("post(\"url\", \"body\")", "post", List.of("url", "body")),
+                Arguments.of("query(\"say \\\"hi\\\"\")", "query", List.of("say \"hi\"")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validExpressions")
+    void parsesValidExpressions(String input, String expectedMethodName, List<String> expectedArguments) {
+        var expression = SamplerExpression.parse(input);
+
+        assertThat(expression.methodName()).isEqualTo(expectedMethodName);
+        assertThat(expression.arguments()).isEqualTo(expectedArguments);
+    }
+
+    @Test
+    void missingMethodNameThrows() {
+        assertThatThrownBy(() -> SamplerExpression.parse("(\"x\")"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Expected method name");
+    }
+
+    @Test
+    void missingOpenParenThrows() {
+        assertThatThrownBy(() -> SamplerExpression.parse("query \"x\")"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Expected '('");
+    }
+
+    @Test
+    void unterminatedStringThrows() {
+        assertThatThrownBy(() -> SamplerExpression.parse("query(\"unterminated"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unterminated string literal");
+    }
+
+    @Test
+    void missingClosingParenThrows() {
+        assertThatThrownBy(() -> SamplerExpression.parse("query(\"a\""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Expected ',' or ')'");
+    }
+
+    @Test
+    void trailingCharactersThrow() {
+        assertThatThrownBy(() -> SamplerExpression.parse("query(\"a\")trailing"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unexpected trailing characters");
+    }
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `./mvnw -pl roadrunner-samplers-spi -am test`
+Expected: COMPILE ERROR — `SamplerExpression` does not exist.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `roadrunner-samplers-spi/src/main/java/io/roadrunner/samplers/spi/SamplerExpression.java`:
+
+```java
+/**
+ * Copyright 2024 Symentis.pl
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.roadrunner.samplers.spi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parses a sampler operation expression: a method name followed by zero or more quoted string
+ * literals, e.g. {@code query("SELECT * FROM table")} or {@code post("url", "body")}.
+ *
+ * <p>Grammar: {@code expression := name '(' ( stringLiteral (',' stringLiteral)* )? ')'}
+ */
+public record SamplerExpression(String methodName, List<String> arguments) {
+
+    public static SamplerExpression parse(String input) {
+        char[] chars = input.toCharArray();
+        int pos = 0;
+
+        int nameStart = pos;
+        while (pos < chars.length && Character.isLetterOrDigit(chars[pos])) {
+            pos++;
+        }
+        if (pos == nameStart) {
+            throw new IllegalArgumentException("Expected method name at position %d in '%s'".formatted(pos, input));
+        }
+        String methodName = input.substring(nameStart, pos);
+
+        if (pos >= chars.length || chars[pos] != '(') {
+            throw new IllegalArgumentException("Expected '(' at position %d in '%s'".formatted(pos, input));
+        }
+        pos++;
+        pos = skipWhitespace(pos, chars);
+
+        List<String> arguments = new ArrayList<>();
+        if (pos < chars.length && chars[pos] == ')') {
+            pos++;
+            requireExhausted(pos, chars, input);
+            return new SamplerExpression(methodName, arguments);
+        }
+
+        while (true) {
+            if (pos >= chars.length || chars[pos] != '"') {
+                throw new IllegalArgumentException("Expected '\"' at position %d in '%s'".formatted(pos, input));
+            }
+            pos++;
+
+            StringBuilder literal = new StringBuilder();
+            while (true) {
+                if (pos >= chars.length) {
+                    throw new IllegalArgumentException("Unterminated string literal in '%s'".formatted(input));
+                }
+                char ch = chars[pos];
+                if (ch == '\\') {
+                    pos++;
+                    if (pos >= chars.length) {
+                        throw new IllegalArgumentException("Unterminated escape sequence in '%s'".formatted(input));
+                    }
+                    char escaped = chars[pos];
+                    if (escaped != '"' && escaped != '\\') {
+                        throw new IllegalArgumentException(
+                                "Invalid escape sequence '\\%s' in '%s'".formatted(escaped, input));
+                    }
+                    literal.append(escaped);
+                    pos++;
+                } else if (ch == '"') {
+                    pos++;
+                    break;
+                } else {
+                    literal.append(ch);
+                    pos++;
+                }
+            }
+            arguments.add(literal.toString());
+            pos = skipWhitespace(pos, chars);
+
+            if (pos >= chars.length) {
+                throw new IllegalArgumentException(
+                        "Expected ',' or ')' at position %d in '%s'".formatted(pos, input));
+            }
+            if (chars[pos] == ')') {
+                pos++;
+                break;
+            }
+            if (chars[pos] != ',') {
+                throw new IllegalArgumentException(
+                        "Expected ',' or ')' at position %d in '%s'".formatted(pos, input));
+            }
+            pos++;
+            pos = skipWhitespace(pos, chars);
+        }
+
+        requireExhausted(pos, chars, input);
+        return new SamplerExpression(methodName, arguments);
+    }
+
+    private static int skipWhitespace(int pos, char[] chars) {
+        while (pos < chars.length && Character.isWhitespace(chars[pos])) {
+            pos++;
+        }
+        return pos;
+    }
+
+    private static void requireExhausted(int pos, char[] chars, String input) {
+        if (pos != chars.length) {
+            throw new IllegalArgumentException(
+                    "Unexpected trailing characters at position %d in '%s'".formatted(pos, input));
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `./mvnw -pl roadrunner-samplers-spi -am test`
+Expected: PASS (all `SamplerExpressionTest` cases green).
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+./mvnw spotless:apply -pl roadrunner-samplers-spi
+git add roadrunner-samplers-spi/pom.xml \
+        roadrunner-samplers-spi/src/main/java/io/roadrunner/samplers/spi/SamplerExpression.java \
+        roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/SamplerExpressionTest.java
+git commit -m "Add SamplerExpression parser for sampler operation CLI syntax"
+```
+
+---
+
+### Task 2: `SamplerExtensionPoint` binder
+
+**Files:**
+- Create: `roadrunner-samplers-spi/src/main/java/io/roadrunner/samplers/spi/SamplerExtensionPoint.java`
+- Test: `roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/SamplerExtensionPointTest.java`
+
+**Interfaces:**
+- Consumes: `SamplerExpression` (Task 1) — `methodName()`, `arguments()`. `io.roadrunner.api.samplers.Sampler` (existing, single abstract method `execute(SamplerParameters)`). `io.roadrunner.samplers.spi.PluginInitializationException` (existing, `roadrunner-samplers-spi`, constructor `(String message, Throwable cause)`).
+- Produces: `final class SamplerExtensionPoint` with `static Supplier<Sampler> bind(Object target, SamplerExpression expression)`. Consumed by `JDBCSamplerProvider`/`Neo4jSamplerProvider` in Tasks 3–4.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/SamplerExtensionPointTest.java`:
+
+```java
+/**
+ * Copyright 2024 Symentis.pl
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.roadrunner.samplers.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.roadrunner.api.events.SamplerResponse;
+import io.roadrunner.api.parameters.SamplerParameters;
+import io.roadrunner.api.samplers.Sampler;
+import org.junit.jupiter.api.Test;
+
+class SamplerExtensionPointTest {
+
+    public static class QueryFixture {
+        private String lastSql;
+
+        public Sampler query(String sql) {
+            this.lastSql = sql;
+            return parameters -> SamplerResponse.empty(0, 0);
+        }
+
+        public Sampler noArgs() {
+            return parameters -> SamplerResponse.empty(0, 0);
+        }
+
+        public String lastSql() {
+            return lastSql;
+        }
+    }
+
+    public static class NonStringParameterFixture {
+        public Sampler withInt(int notAString) {
+            return parameters -> SamplerResponse.empty(0, 0);
+        }
+    }
+
+    @Test
+    void bindsSingleArgumentMethodAndPassesTheLiteral() {
+        var expression = SamplerExpression.parse("query(\"SELECT 1\")");
+        var fixture = new QueryFixture();
+
+        var sampler = SamplerExtensionPoint.bind(fixture, expression).get();
+        var response = sampler.execute(SamplerParameters.NONE);
+
+        assertThat(fixture.lastSql()).isEqualTo("SELECT 1");
+        assertThat(response).isInstanceOf(SamplerResponse.Response.class);
+    }
+
+    @Test
+    void bindsZeroArgumentMethodAmongMultipleCandidates() {
+        var expression = SamplerExpression.parse("noArgs()");
+        var fixture = new QueryFixture();
+
+        var sampler = SamplerExtensionPoint.bind(fixture, expression).get();
+        var response = sampler.execute(SamplerParameters.NONE);
+
+        assertThat(response).isInstanceOf(SamplerResponse.Response.class);
+    }
+
+    @Test
+    void eachSupplierInvocationProducesAFreshSampler() {
+        var expression = SamplerExpression.parse("query(\"SELECT 1\")");
+        var samplerSupplier = SamplerExtensionPoint.bind(new QueryFixture(), expression);
+
+        assertThat(samplerSupplier.get()).isNotSameAs(samplerSupplier.get());
+    }
+
+    @Test
+    void unknownMethodNameThrows() {
+        var expression = SamplerExpression.parse("update(\"SELECT 1\")");
+
+        assertThatThrownBy(() -> SamplerExtensionPoint.bind(new QueryFixture(), expression))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("update");
+    }
+
+    @Test
+    void arityMismatchThrows() {
+        var expression = SamplerExpression.parse("query(\"a\", \"b\")");
+
+        assertThatThrownBy(() -> SamplerExtensionPoint.bind(new QueryFixture(), expression))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("query");
+    }
+
+    @Test
+    void nonStringParameterThrows() {
+        var expression = SamplerExpression.parse("withInt(\"1\")");
+
+        assertThatThrownBy(() -> SamplerExtensionPoint.bind(new NonStringParameterFixture(), expression))
+                .isInstanceOf(PluginInitializationException.class)
+                .hasMessageContaining("withInt");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./mvnw -pl roadrunner-samplers-spi -am test`
+Expected: COMPILE ERROR — `SamplerExtensionPoint` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `roadrunner-samplers-spi/src/main/java/io/roadrunner/samplers/spi/SamplerExtensionPoint.java`:
+
+```java
+/**
+ * Copyright 2024 Symentis.pl
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.roadrunner.samplers.spi;
+
+import io.roadrunner.api.samplers.Sampler;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Binds a parsed {@link SamplerExpression} to a matching {@code Sampler}-returning method on a
+ * target object, producing a factory for the resulting {@link Sampler}.
+ *
+ * <p>Uses {@link MethodHandles#publicLookup()} rather than {@link MethodHandles#lookup()}: the
+ * target class typically lives in a different Maven/JPMS module than this class, and this module
+ * must not gain a {@code requires} edge back onto every sampler module that uses it.
+ */
+public final class SamplerExtensionPoint {
+
+    private SamplerExtensionPoint() {}
+
+    public static Supplier<Sampler> bind(Object target, SamplerExpression expression) {
+        List<Method> candidates = candidateMethods(target.getClass());
+
+        List<Method> matching = candidates.stream()
+                .filter(method -> method.getName().equals(expression.methodName()))
+                .filter(method -> method.getParameterCount() == expression.arguments().size())
+                .toList();
+
+        if (matching.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "No Sampler-returning method named '%s' with %d argument(s) on %s. Available: %s"
+                            .formatted(
+                                    expression.methodName(),
+                                    expression.arguments().size(),
+                                    target.getClass().getName(),
+                                    describe(candidates)));
+        }
+
+        Method method = matching.get(0);
+
+        MethodHandle handle;
+        try {
+            handle = MethodHandles.publicLookup().unreflect(method);
+        } catch (IllegalAccessException e) {
+            throw new PluginInitializationException(
+                    "Cannot access extension point method '%s' on %s"
+                            .formatted(method.getName(), target.getClass().getName()),
+                    e);
+        }
+
+        Object[] boundArguments = prependTarget(target, expression.arguments());
+        MethodHandle boundHandle = MethodHandles.insertArguments(handle, 0, boundArguments);
+
+        return () -> {
+            try {
+                return (Sampler) boundHandle.invoke();
+            } catch (Throwable t) {
+                throw new IllegalStateException(
+                        "Failed to invoke extension point method '%s' on %s"
+                                .formatted(method.getName(), target.getClass().getName()),
+                        t);
+            }
+        };
+    }
+
+    private static List<Method> candidateMethods(Class<?> type) {
+        List<Method> candidates = new ArrayList<>();
+        for (Method method : type.getMethods()) {
+            if (method.getReturnType() != Sampler.class) {
+                continue;
+            }
+            for (Class<?> parameterType : method.getParameterTypes()) {
+                if (parameterType != String.class) {
+                    throw new PluginInitializationException(
+                            "Extension point method '%s' on %s has non-String parameter of type %s"
+                                    .formatted(method.getName(), type.getName(), parameterType.getName()),
+                            null);
+                }
+            }
+            candidates.add(method);
+        }
+        return candidates;
+    }
+
+    private static Object[] prependTarget(Object target, List<String> arguments) {
+        Object[] withTarget = new Object[arguments.size() + 1];
+        withTarget[0] = target;
+        for (int i = 0; i < arguments.size(); i++) {
+            withTarget[i + 1] = arguments.get(i);
+        }
+        return withTarget;
+    }
+
+    private static String describe(List<Method> candidates) {
+        return candidates.stream()
+                .map(m -> "%s(%d args)".formatted(m.getName(), m.getParameterCount()))
+                .collect(Collectors.joining(", "));
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./mvnw -pl roadrunner-samplers-spi -am test`
+Expected: PASS (all `SamplerExtensionPointTest` cases green).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+./mvnw spotless:apply -pl roadrunner-samplers-spi
+git add roadrunner-samplers-spi/src/main/java/io/roadrunner/samplers/spi/SamplerExtensionPoint.java \
+        roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/SamplerExtensionPointTest.java
+git commit -m "Add SamplerExtensionPoint: MethodHandle-bind a parsed expression to a Sampler factory"
+```
+
+---
+
+### Task 3: Migrate the JDBC sampler
+
+**Files:**
+- Create: `roadrunner-sampler-jdbc/src/main/java/io/roadrunner/samplers/jdbc/JDBCSampler.java`
+- Modify: `roadrunner-sampler-jdbc/src/main/java/io/roadrunner/samplers/jdbc/JDBCSamplerProvider.java`
+- Modify: `roadrunner-sampler-jdbc/src/main/java/io/roadrunner/samplers/jdbc/JDBCSamplerPlugin.java:47` (the `new JDBCSamplerProvider(dataSource, options.query)` line)
+- Modify: `roadrunner-sampler-jdbc/src/it/java/io/roadrunner/samplers/jdbc/tests/JDBCSamplerProviderIT.java:201-209` (`defaultSamplerOptions` helper)
+
+**Interfaces:**
+- Consumes: `SamplerExpression.parse(String)` (Task 1), `SamplerExtensionPoint.bind(Object, SamplerExpression)` (Task 2).
+- Produces: `JDBCSampler` with `Sampler query(String sql)`, `long sampleCount()`, `long totalAcquireNanos()`, `long totalQueryNanos()`, `Connection getConnection()`. `JDBCSamplerProvider` keeps its existing public surface — `newSampler()`, `sampleCount()`, `totalAcquireNanos()`, `totalQueryNanos()`, `close()`, `getConnection()`, plus a new `(DataSource, SamplerExpression)` constructor alongside the existing `(DataSource, String)` one.
+
+No new module-info changes: `roadrunner-sampler-jdbc`'s `module-info.java` already has `requires io.roadrunner.samplers.spi;` and `exports io.roadrunner.samplers.jdbc;` (unconditional), which is everything `MethodHandles.publicLookup()` needs.
+
+- [ ] **Step 1: Extract `JDBCSampler` — move the existing lambda body out of `JDBCSamplerProvider`**
+
+Create `roadrunner-sampler-jdbc/src/main/java/io/roadrunner/samplers/jdbc/JDBCSampler.java` (this is today's `JDBCSamplerProvider` body, moved verbatim into a method-shaped form):
+
+```java
+/**
+ * Copyright 2024 Symentis.pl
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.roadrunner.samplers.jdbc;
+
+import static java.util.Map.entry;
+import static java.util.Objects.requireNonNull;
+
+import io.roadrunner.api.events.SamplerResponse;
+import io.roadrunner.api.parameters.SamplerParameters;
+import io.roadrunner.api.samplers.Sampler;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Connection;
+import java.sql.JDBCType;
+import java.sql.SQLException;
+import java.sql.SQLType;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
+import javax.sql.DataSource;
+
+/**
+ * Extension-point methods class for the JDBC sampler: {@link #query(String)} is bound from a CLI
+ * {@code query("SELECT ...")} expression via {@link io.roadrunner.samplers.spi.SamplerExtensionPoint}.
+ */
+public class JDBCSampler {
+
+    private final DataSource dataSource;
+    private final LongAdder sampleCount = new LongAdder();
+    private final LongAdder acquireNanos = new LongAdder();
+    private final LongAdder queryNanos = new LongAdder();
+
+    public JDBCSampler(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public Sampler query(String sql) {
+        return (SamplerParameters parameters) -> {
+            var tStarted = System.nanoTime();
+            try (var cnn = dataSource.getConnection();
+                    var stmt = cnn.prepareStatement(sql)) {
+                var tAcquired = System.nanoTime();
+                try {
+                    long rowCount;
+                    parameters.forEach((index, type, value) -> stmt.setObject(index + 1, value, sqlTypeOf(type)));
+                    boolean hasResultSet = stmt.execute();
+                    if (hasResultSet) {
+                        try (var rs = stmt.getResultSet()) {
+                            rowCount = 0;
+                            while (rs.next()) {
+                                rowCount++;
+                            }
+                        }
+                    } else {
+                        rowCount = stmt.getUpdateCount();
+                    }
+                    var tDone = System.nanoTime();
+                    recordTimestamps(tStarted, tAcquired, tDone);
+                    return SamplerResponse.response(tStarted, tDone, rowCount);
+                } catch (Exception e) {
+                    var tDone = System.nanoTime();
+                    recordTimestamps(tStarted, tAcquired, tDone);
+                    return SamplerResponse.error(tStarted, tDone, e.getMessage());
+                }
+            } catch (SQLException e) {
+                var tDone = System.nanoTime();
+                // Connection acquisition failed: entire window is acquire time.
+                recordTimestamps(tStarted, tDone, tDone);
+                return SamplerResponse.error(tStarted, tDone, e.getMessage());
+            }
+        };
+    }
+
+    /**
+     * Java to SQL type mapping per the JDBC 4.3 spec (table B-4 / appendix B). Only the exact
+     * runtime classes a {@link io.roadrunner.api.parameters.ParameterSource} can produce are
+     * listed — subtypes (e.g. {@code java.util.Date}, {@code Number}) and primitive class
+     * literals (unreachable since values arrive via {@link Object#getClass()}) are out of scope.
+     */
+    private static final Map<Class<?>, SQLType> SQL_TYPE_BY_JAVA_TYPE = Map.ofEntries(
+            entry(String.class, JDBCType.VARCHAR),
+            entry(Character.class, JDBCType.CHAR),
+            entry(Boolean.class, JDBCType.BOOLEAN),
+            entry(Byte.class, JDBCType.TINYINT),
+            entry(Short.class, JDBCType.SMALLINT),
+            entry(Integer.class, JDBCType.INTEGER),
+            entry(Long.class, JDBCType.BIGINT),
+            entry(Float.class, JDBCType.REAL),
+            entry(Double.class, JDBCType.DOUBLE),
+            entry(BigDecimal.class, JDBCType.DECIMAL),
+            entry(BigInteger.class, JDBCType.NUMERIC),
+            entry(byte[].class, JDBCType.VARBINARY),
+            entry(java.sql.Date.class, JDBCType.DATE),
+            entry(java.sql.Time.class, JDBCType.TIME),
+            entry(java.sql.Timestamp.class, JDBCType.TIMESTAMP),
+            entry(LocalDate.class, JDBCType.DATE),
+            entry(LocalTime.class, JDBCType.TIME),
+            entry(LocalDateTime.class, JDBCType.TIMESTAMP),
+            entry(OffsetTime.class, JDBCType.TIME_WITH_TIMEZONE),
+            entry(OffsetDateTime.class, JDBCType.TIMESTAMP_WITH_TIMEZONE));
+
+    private static SQLType sqlTypeOf(Class<?> type) {
+        return requireNonNull(
+                SQL_TYPE_BY_JAVA_TYPE.get(type),
+                () -> "unsupported Java type for JDBC parameter binding: " + type.getName());
+    }
+
+    private void recordTimestamps(long tStarted, long tAcquired, long tDone) {
+        sampleCount.increment();
+        acquireNanos.add(tAcquired - tStarted);
+        queryNanos.add(tDone - tAcquired);
+    }
+
+    public long sampleCount() {
+        return sampleCount.sum();
+    }
+
+    public long totalAcquireNanos() {
+        return acquireNanos.sum();
+    }
+
+    public long totalQueryNanos() {
+        return queryNanos.sum();
+    }
+
+    public Connection getConnection() throws SQLException {
+        return dataSource.getConnection();
+    }
+}
+```
+
+- [ ] **Step 2: Rewrite `JDBCSamplerProvider` as a thin wrapper**
+
+Replace the full contents of `roadrunner-sampler-jdbc/src/main/java/io/roadrunner/samplers/jdbc/JDBCSamplerProvider.java`:
+
+```java
+/**
+ * Copyright 2024 Symentis.pl
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.roadrunner.samplers.jdbc;
+
+import io.roadrunner.api.samplers.Sampler;
+import io.roadrunner.api.samplers.SamplerProvider;
+import io.roadrunner.samplers.spi.SamplerExpression;
+import io.roadrunner.samplers.spi.SamplerExtensionPoint;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.function.Supplier;
+import javax.sql.DataSource;
+
+public class JDBCSamplerProvider implements SamplerProvider {
+
+    private final JDBCSampler jdbcSampler;
+    private final Supplier<Sampler> samplerSupplier;
+
+    public JDBCSamplerProvider(DataSource dataSource, String sql) {
+        this.jdbcSampler = new JDBCSampler(dataSource);
+        this.samplerSupplier = () -> jdbcSampler.query(sql);
+    }
+
+    public JDBCSamplerProvider(DataSource dataSource, SamplerExpression expression) {
+        this.jdbcSampler = new JDBCSampler(dataSource);
+        this.samplerSupplier = SamplerExtensionPoint.bind(jdbcSampler, expression);
+    }
+
+    @Override
+    public Sampler newSampler() {
+        return samplerSupplier.get();
+    }
+
+    public long sampleCount() {
+        return jdbcSampler.sampleCount();
+    }
+
+    public long totalAcquireNanos() {
+        return jdbcSampler.totalAcquireNanos();
+    }
+
+    public long totalQueryNanos() {
+        return jdbcSampler.totalQueryNanos();
+    }
+
+    @Override
+    public void close() {
+        // Pool lifecycle is owned by JDBCSamplerPlugin.
+    }
+
+    public Connection getConnection() throws SQLException {
+        return jdbcSampler.getConnection();
+    }
+}
+```
+
+The `(DataSource, String)` constructor is unchanged from the caller's point of view (used directly by `JDBCSamplerProviderIT.errorOnConnectionFailure`, which stays untouched) — it just builds a `JDBCSampler` internally now instead of hand-writing the lambda inline.
+
+- [ ] **Step 3: Wire the CLI-parsed expression through `JDBCSamplerPlugin`**
+
+In `roadrunner-sampler-jdbc/src/main/java/io/roadrunner/samplers/jdbc/JDBCSamplerPlugin.java`, add the import:
+
+```java
+import io.roadrunner.samplers.spi.SamplerExpression;
+```
+
+And change this line inside `newSamplerProvider`:
+
+```java
+provider = new JDBCSamplerProvider(dataSource, options.query);
+```
+
+to:
+
+```java
+provider = new JDBCSamplerProvider(dataSource, SamplerExpression.parse(options.query));
+```
+
+`JDBCSamplerOptions.query` (the existing `@Parameters public String query` positional) now holds a full expression string, e.g. `query("SELECT * FROM table WHERE id = ?")`, instead of a bare SQL string. No change to `JDBCSamplerOptions.java` itself — only the meaning of the string it captures changes, which is why the IT test's helper needs to wrap the SQL in `query(...)` (next step).
+
+- [ ] **Step 4: Update the JDBC integration test to use the new expression syntax**
+
+In `roadrunner-sampler-jdbc/src/it/java/io/roadrunner/samplers/jdbc/tests/JDBCSamplerProviderIT.java`, change the `defaultSamplerOptions` helper:
+
+```java
+private static JDBCSamplerOptions defaultSamplerOptions(JDBCSamplerPlugin plugin, String url, String query) {
+    var options = plugin.options();
+    options.url = url;
+    options.username = "SA";
+    options.password = "";
+    options.query = "query(\"%s\")".formatted(query);
+    options.driverPath = Paths.get(DRIVER_PATH);
+    return options;
+}
+```
+
+(Only the `options.query = query;` line changes to `options.query = "query(\"%s\")".formatted(query);` — every caller of this helper keeps passing bare SQL and is unaffected.) `errorOnConnectionFailure`, which constructs `new JDBCSamplerProvider(failingDataSource, "SELECT 1")` directly (bypassing options/plugin entirely), needs no change — it already uses the untouched `(DataSource, String)` constructor.
+
+- [ ] **Step 5: Run unit and integration tests to verify they pass**
+
+Run: `./mvnw -pl roadrunner-sampler-jdbc -am verify`
+Expected: PASS — all `JDBCSamplerProviderIT` cases green (uses the hsqldb driver copied into `target/jdbc-drivers` by the `pre-integration-test` phase already configured in the module's `pom.xml`).
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+./mvnw spotless:apply -pl roadrunner-sampler-jdbc
+git add roadrunner-sampler-jdbc/src/main/java/io/roadrunner/samplers/jdbc/JDBCSampler.java \
+        roadrunner-sampler-jdbc/src/main/java/io/roadrunner/samplers/jdbc/JDBCSamplerProvider.java \
+        roadrunner-sampler-jdbc/src/main/java/io/roadrunner/samplers/jdbc/JDBCSamplerPlugin.java \
+        roadrunner-sampler-jdbc/src/it/java/io/roadrunner/samplers/jdbc/tests/JDBCSamplerProviderIT.java
+git commit -m "Migrate JDBC sampler onto the SamplerExtensionPoint mechanism"
+```
+
+---
+
+### Task 4: Migrate the Neo4j sampler
+
+**Files:**
+- Create: `roadrunner-sampler-neo4j/src/main/java/io/roadrunner/samplers/neo4j/Neo4jSampler.java`
+- Modify: `roadrunner-sampler-neo4j/src/main/java/io/roadrunner/samplers/neo4j/Neo4jSamplerProvider.java`
+- Modify: `roadrunner-sampler-neo4j/src/main/java/io/roadrunner/samplers/neo4j/Neo4jSamplerPlugin.java:34-38`
+- Modify: `roadrunner-sampler-neo4j/src/it/java/io/roadrunner/samplers/neo4j/Neo4jSamplerPluginIT.java`
+
+**Interfaces:**
+- Consumes: `SamplerExpression.parse(String)` (Task 1), `SamplerExtensionPoint.bind(Object, SamplerExpression)` (Task 2).
+- Produces: `Neo4jSampler` with `Sampler query(String cypher)` and `void close()`. `Neo4jSamplerProvider` keeps `newSampler()`/`close()`, plus a new `(Driver, SamplerExpression)` constructor alongside the existing `(Driver, String)` one.
+
+No `module-info.java` changes needed (same reasoning as Task 3: `requires io.roadrunner.samplers.spi;` and unconditional `exports io.roadrunner.samplers.neo4j;` already present).
+
+- [ ] **Step 1: Extract `Neo4jSampler`**
+
+Create `roadrunner-sampler-neo4j/src/main/java/io/roadrunner/samplers/neo4j/Neo4jSampler.java`:
+
+```java
+/**
+ * Copyright 2024 Symentis.pl
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.roadrunner.samplers.neo4j;
+
+import io.roadrunner.api.events.SamplerResponse;
+import io.roadrunner.api.samplers.Sampler;
+import java.util.Map;
+import org.neo4j.driver.Driver;
+
+/**
+ * Extension-point methods class for the Neo4j sampler: {@link #query(String)} is bound from a
+ * CLI {@code query("RETURN 1")} expression via {@link io.roadrunner.samplers.spi.SamplerExtensionPoint}.
+ */
+public class Neo4jSampler {
+
+    private final Driver driver;
+
+    public Neo4jSampler(Driver driver) {
+        this.driver = driver;
+    }
+
+    public Sampler query(String cypher) {
+        return parameters -> {
+            var startTime = System.nanoTime();
+            try (var session = driver.session()) {
+                // Neo4j's Session.run accepts Map<String, Object>; SamplerParameters.asMap returns
+                // Map<String, ?>. Erasure makes the cast safe — Session.run is a read-only consumer
+                // of the map. See #137 for typed CSV values (Integer/Long/etc. instead of String).
+                @SuppressWarnings("unchecked")
+                var params = (Map<String, Object>) parameters.asMap();
+                var result = session.run(cypher, params);
+                return SamplerResponse.response(startTime, System.nanoTime(), result.consume());
+            } catch (Exception e) {
+                return SamplerResponse.error(startTime, System.nanoTime(), e.getMessage());
+            }
+        };
+    }
+
+    public void close() {
+        driver.close();
+    }
+}
+```
+
+- [ ] **Step 2: Rewrite `Neo4jSamplerProvider` as a thin wrapper**
+
+Replace the full contents of `roadrunner-sampler-neo4j/src/main/java/io/roadrunner/samplers/neo4j/Neo4jSamplerProvider.java`:
+
+```java
+/**
+ * Copyright 2024 Symentis.pl
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.roadrunner.samplers.neo4j;
+
+import io.roadrunner.api.samplers.Sampler;
+import io.roadrunner.api.samplers.SamplerProvider;
+import io.roadrunner.samplers.spi.SamplerExpression;
+import io.roadrunner.samplers.spi.SamplerExtensionPoint;
+import java.util.function.Supplier;
+import org.neo4j.driver.Driver;
+
+public class Neo4jSamplerProvider implements SamplerProvider {
+
+    private final Neo4jSampler neo4jSampler;
+    private final Supplier<Sampler> samplerSupplier;
+
+    public Neo4jSamplerProvider(Driver driver, String cypher) {
+        this.neo4jSampler = new Neo4jSampler(driver);
+        this.samplerSupplier = () -> neo4jSampler.query(cypher);
+    }
+
+    public Neo4jSamplerProvider(Driver driver, SamplerExpression expression) {
+        this.neo4jSampler = new Neo4jSampler(driver);
+        this.samplerSupplier = SamplerExtensionPoint.bind(neo4jSampler, expression);
+    }
+
+    @Override
+    public Sampler newSampler() {
+        return samplerSupplier.get();
+    }
+
+    @Override
+    public void close() {
+        neo4jSampler.close();
+    }
+}
+```
+
+- [ ] **Step 3: Wire the CLI-parsed expression through `Neo4jSamplerPlugin`**
+
+In `roadrunner-sampler-neo4j/src/main/java/io/roadrunner/samplers/neo4j/Neo4jSamplerPlugin.java`, add the import:
+
+```java
+import io.roadrunner.samplers.spi.SamplerExpression;
+```
+
+And change `newSamplerProvider`:
+
+```java
+@Override
+public Neo4jSamplerProvider newSamplerProvider(Neo4jSamplerOptions options) {
+    var driver = GraphDatabase.driver(options.uri, AuthTokens.basic(options.username, options.password));
+
+    return new Neo4jSamplerProvider(driver, SamplerExpression.parse(options.query));
+}
+```
+
+- [ ] **Step 4: Update the Neo4j integration test to use the new expression syntax**
+
+In `roadrunner-sampler-neo4j/src/it/java/io/roadrunner/samplers/neo4j/Neo4jSamplerPluginIT.java`, update all three tests. `invalidQuery` previously left `options.query` unset (`null`) to exercise Neo4j's own "query text should not be null" validation; with the new syntax `options.query` is now always a parseable expression (a null/missing value would fail in `SamplerExpression.parse` before ever reaching Neo4j, with a different, clearer message), so this test now exercises an *empty* cypher literal instead, and asserts only that an error surfaces (not the exact driver wording, which may differ):
+
+```java
+@Test
+void invalidQuery() throws Exception {
+    try (var plugin = new Neo4jSamplerPlugin()) {
+        var options = plugin.options();
+        options.uri = new URI("neo4j://%s:%d".formatted(neo4j.getHost(), neo4j.getMappedPort(7687)));
+        options.username = "neo4j";
+        options.password = "";
+        options.query = "query(\"\")";
+        try (var samplerProvider = options.samplerProvider()) {
+            var sampler = samplerProvider.newSampler();
+            var response = sampler.execute(SamplerParameters.NONE);
+            assertThat(response).asInstanceOf(type(SamplerResponse.Error.class)).satisfies(e -> {
+                assertThat(e.timestamp()).isLessThanOrEqualTo(e.stopTime());
+                assertThat(e.stopTime()).isLessThanOrEqualTo(System.nanoTime());
+                assertThat(e.message()).isNotBlank();
+            });
+        }
+    }
+}
+
+@Test
+void validQuery() throws Exception {
+    try (var plugin = new Neo4jSamplerPlugin()) {
+        var options = plugin.options();
+        options.uri = new URI("neo4j://%s:%d".formatted(neo4j.getHost(), neo4j.getMappedPort(7687)));
+        options.username = "neo4j";
+        options.password = "";
+        options.query = "query(\"RETURN 1\")";
+        try (var samplerProvider = options.samplerProvider()) {
+            var sampler = samplerProvider.newSampler();
+            var response = sampler.execute(SamplerParameters.NONE);
+            assertThat(response).asInstanceOf(type(SamplerResponse.Response.class)).satisfies(r -> assertThat(r.timestamp()).isLessThanOrEqualTo(System.nanoTime()));
+        }
+    }
+}
+
+@Test
+void validParameterizedQuery() throws Exception {
+    try (var plugin = new Neo4jSamplerPlugin()) {
+        var options = plugin.options();
+        options.uri = new URI("neo4j://%s:%d".formatted(neo4j.getHost(), neo4j.getMappedPort(7687)));
+        options.username = "neo4j";
+        options.password = "";
+        options.query = "query(\"RETURN $param\")";
+        try (var samplerProvider = options.samplerProvider()) {
+            var sampler = samplerProvider.newSampler();
+            var response = sampler.execute(SamplerParameters.of("param", "1"));
+            assertThat(response).asInstanceOf(type(SamplerResponse.Response.class))
+                    .satisfies(r -> {
+                        assertThat(r.timestamp()).isLessThanOrEqualTo(r.stopTime());
+                        assertThat(r.stopTime()).isLessThanOrEqualTo(System.nanoTime());
+                    });
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run integration tests to verify they pass**
+
+Run: `./mvnw -pl roadrunner-sampler-neo4j -am verify`
+Expected: PASS — all `Neo4jSamplerPluginIT` cases green (requires Docker for the Neo4j Testcontainers container).
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+./mvnw spotless:apply -pl roadrunner-sampler-neo4j
+git add roadrunner-sampler-neo4j/src/main/java/io/roadrunner/samplers/neo4j/Neo4jSampler.java \
+        roadrunner-sampler-neo4j/src/main/java/io/roadrunner/samplers/neo4j/Neo4jSamplerProvider.java \
+        roadrunner-sampler-neo4j/src/main/java/io/roadrunner/samplers/neo4j/Neo4jSamplerPlugin.java \
+        roadrunner-sampler-neo4j/src/it/java/io/roadrunner/samplers/neo4j/Neo4jSamplerPluginIT.java
+git commit -m "Migrate Neo4j sampler onto the SamplerExtensionPoint mechanism"
+```
+
+---
+
+### Task 5: Dispatch microbenchmark (direct vs `MethodHandle` vs reflection)
+
+**Files:**
+- Create: `roadrunner-microbenchmarks/src/main/java/io/roadrunner/SamplerFactoryDispatchBenchmarks.java`
+
+**Interfaces:**
+- Consumes: `io.roadrunner.api.samplers.Sampler`, `io.roadrunner.api.events.SamplerResponse` (both already on the module's compile classpath transitively via the existing `roadrunner-core` dependency — no `pom.xml` change needed, same as how `RoadrunnerBenchmarks.java` already imports them without an explicit `roadrunner-api` dependency entry).
+- Produces: a standalone JMH benchmark class, not consumed by any other task.
+
+This task has no unit-test red/green cycle (JMH benchmarks aren't assertions) — "passing" means the benchmark jar builds and a short smoke run executes cleanly.
+
+- [ ] **Step 1: Write the benchmark**
+
+Create `roadrunner-microbenchmarks/src/main/java/io/roadrunner/SamplerFactoryDispatchBenchmarks.java`:
+
+```java
+/**
+ * Copyright 2024 Symentis.pl
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.roadrunner;
+
+import io.roadrunner.api.events.SamplerResponse;
+import io.roadrunner.api.samplers.Sampler;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Compares three ways of turning a resolved target + literal argument into a {@link Sampler},
+ * at the frequency {@code SamplerProvider.newSampler()} is actually called (once per virtual
+ * thread) — see the "Microbenchmarks" section of
+ * docs/superpowers/specs/2026-07-13-sampler-method-extension-points-design.md. This does not
+ * measure the per-request {@code execute()} hot path, which is unaffected by this design either
+ * way.
+ */
+public class SamplerFactoryDispatchBenchmarks {
+
+    public static class DispatchFixture {
+        public Sampler query(String sql) {
+            return parameters -> SamplerResponse.empty(0, 0);
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class DispatchState {
+        DispatchFixture fixture;
+        String sql;
+        MethodHandle boundHandle;
+        Method reflectMethod;
+
+        @Setup(Level.Trial)
+        public void setUp() throws Exception {
+            fixture = new DispatchFixture();
+            sql = "SELECT 1";
+            reflectMethod = DispatchFixture.class.getMethod("query", String.class);
+            MethodHandle handle = MethodHandles.publicLookup().unreflect(reflectMethod);
+            boundHandle = MethodHandles.insertArguments(handle, 0, fixture, sql);
+        }
+    }
+
+    @Benchmark
+    @Fork(value = 1, warmups = 1)
+    public Sampler directDispatch(DispatchState state) {
+        return state.fixture.query(state.sql);
+    }
+
+    @Benchmark
+    @Fork(value = 1, warmups = 1)
+    public Sampler methodHandleDispatch(DispatchState state) throws Throwable {
+        return (Sampler) state.boundHandle.invoke();
+    }
+
+    @Benchmark
+    @Fork(value = 1, warmups = 1)
+    public Sampler reflectionDispatch(DispatchState state) throws Exception {
+        return (Sampler) state.reflectMethod.invoke(state.fixture, state.sql);
+    }
+}
+```
+
+- [ ] **Step 2: Build the benchmarks jar**
+
+Run: `./mvnw -pl roadrunner-microbenchmarks -am package -DskipTests`
+Expected: BUILD SUCCESS, producing `roadrunner-microbenchmarks/target/benchmarks.jar`.
+
+- [ ] **Step 3: Smoke-run the new benchmarks with reduced iterations**
+
+Run: `java -jar roadrunner-microbenchmarks/target/benchmarks.jar SamplerFactoryDispatch -f 1 -wi 1 -i 1`
+Expected: all three benchmarks (`directDispatch`, `methodHandleDispatch`, `reflectionDispatch`) execute and print a score — no exceptions. This is a smoke test, not a performance gate; a full comparison run is a separate manual step via `task benchmark:run` per the spec.
+
+- [ ] **Step 4: Format and commit**
+
+```bash
+./mvnw spotless:apply -pl roadrunner-microbenchmarks
+git add roadrunner-microbenchmarks/src/main/java/io/roadrunner/SamplerFactoryDispatchBenchmarks.java
+git commit -m "Add JMH benchmark comparing direct, MethodHandle, and reflection sampler dispatch"
+```

--- a/docs/superpowers/plans/2026-07-13-sampler-method-extension-points.md
+++ b/docs/superpowers/plans/2026-07-13-sampler-method-extension-points.md
@@ -4,7 +4,7 @@
 
 **Goal:** Let a sampler class expose multiple named, type-checked operations (instead of one fixed `execute()`), selected and literal-bound from a small CLI expression (`query("SELECT ...")`), while every existing sampler and downstream engine code keeps working unchanged.
 
-**Architecture:** Two new types in `roadrunner-samplers-spi` — `SamplerExpression` (hand-rolled parser: `name("lit", ...)` → method name + literal args) and `SamplerExtensionPoint` (validates a target object's `Sampler`-returning methods, binds literal args via `MethodHandles.publicLookup()`, returns a `Supplier<Sampler>`). JDBC and Neo4j samplers migrate onto this: their per-call logic moves into a new `JDBCSampler`/`Neo4jSampler` "methods class" exposing `query(String sql)`; their `SamplerProvider`s become thin wrappers delegating to the bound `Supplier<Sampler>`. AB and VM are untouched, proving the old direct-`Sampler`-implementation style still works.
+**Architecture:** Two new types in `roadrunner-samplers-spi`: `SamplerExpression` (hand-rolled parser: `name("lit", ...)` → method name + literal args), which lives in an **unexported** internal package since it's a parsing detail no other module should ever reference directly; and `SamplerExtensionPoint` (the module's only exported entry point for this mechanism — validates a target object's `Sampler`-returning methods, parses the expression internally, binds literal args via `MethodHandles.publicLookup()`, returns a `Supplier<Sampler>`). JDBC and Neo4j samplers migrate onto this: their per-call logic moves into a new `JDBCSampler`/`Neo4jSampler` "methods class" exposing `query(String sql)`; their `SamplerProvider`s become thin wrappers delegating to the bound `Supplier<Sampler>`. AB and VM are untouched, proving the old direct-`Sampler`-implementation style still works.
 
 **Tech Stack:** Java 25, Maven (multi-module, JPMS), JUnit 5 + AssertJ, JMH (`roadrunner-microbenchmarks`), `java.lang.invoke.MethodHandle`s (JDK stdlib, no new dependency).
 
@@ -17,21 +17,22 @@
 - Literal CLI arguments support only `String` in this change — no numeric/`URL`/file-content literals.
 - Binding uses `MethodHandles.publicLookup()`, never `MethodHandles.lookup()` — `roadrunner-samplers-spi` must not gain a `requires` edge onto sampler modules.
 - `SamplerExtensionPoint` validation only inspects methods whose return type is exactly `Sampler`; methods with any other return type are ignored, not rejected.
+- `SamplerExpression` lives in `io.roadrunner.samplers.spi.internal`, which is **not** listed in `roadrunner-samplers-spi`'s `module-info.java` `exports` — no other module may import it. `SamplerExtensionPoint` is the only public entry point (`bind(Object, String)`); it never exposes the parsed IR type in its signature.
 - AB and VM samplers are not touched by this plan.
 - Every new/modified `.java` file gets the existing Apache-2.0 header (copy verbatim from any existing file in the same module) and must pass `./mvnw spotless:apply -pl <module>` (Palantir Java format) before committing.
 - Use `./mvnw` (wrapper) for all build/test commands below, run from the repo root.
 
 ---
 
-### Task 1: `SamplerExpression` parser
+### Task 1: `SamplerExpression` parser (internal)
 
 **Files:**
 - Modify: `roadrunner-samplers-spi/pom.xml`
-- Create: `roadrunner-samplers-spi/src/main/java/io/roadrunner/samplers/spi/SamplerExpression.java`
-- Test: `roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/SamplerExpressionTest.java`
+- Create: `roadrunner-samplers-spi/src/main/java/io/roadrunner/samplers/spi/internal/SamplerExpression.java`
+- Test: `roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/internal/SamplerExpressionTest.java`
 
 **Interfaces:**
-- Produces: `record SamplerExpression(String methodName, List<String> arguments)` with `static SamplerExpression parse(String input)`, throwing `IllegalArgumentException` on malformed input. Package `io.roadrunner.samplers.spi`. Consumed by Task 2 and by `JDBCSamplerPlugin`/`Neo4jSamplerPlugin` in Tasks 3–4.
+- Produces: `record SamplerExpression(String methodName, List<String> arguments)` with `static SamplerExpression parse(String input)`, throwing `IllegalArgumentException` on malformed input. Package `io.roadrunner.samplers.spi.internal` (not exported by `roadrunner-samplers-spi`'s `module-info.java` — no edit needed there, a package absent from `exports` is unexported by default). Consumed only by `SamplerExtensionPoint` (Task 2), which lives in the sibling `io.roadrunner.samplers.spi` package in the *same* module — intra-module access doesn't need `exports`.
 
 - [ ] **Step 1: Add test dependencies to `roadrunner-samplers-spi/pom.xml`**
 
@@ -59,7 +60,7 @@ No test source set exists yet in this module. Add the same test dependencies eve
 
 - [ ] **Step 2: Write the failing test**
 
-Create `roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/SamplerExpressionTest.java`:
+Create `roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/internal/SamplerExpressionTest.java`:
 
 ```java
 /**
@@ -77,7 +78,7 @@ Create `roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/Sampler
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.roadrunner.samplers.spi;
+package io.roadrunner.samplers.spi.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -152,7 +153,7 @@ Expected: COMPILE ERROR — `SamplerExpression` does not exist.
 
 - [ ] **Step 4: Write the implementation**
 
-Create `roadrunner-samplers-spi/src/main/java/io/roadrunner/samplers/spi/SamplerExpression.java`:
+Create `roadrunner-samplers-spi/src/main/java/io/roadrunner/samplers/spi/internal/SamplerExpression.java`:
 
 ```java
 /**
@@ -170,7 +171,7 @@ Create `roadrunner-samplers-spi/src/main/java/io/roadrunner/samplers/spi/Sampler
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.roadrunner.samplers.spi;
+package io.roadrunner.samplers.spi.internal;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -180,6 +181,9 @@ import java.util.List;
  * literals, e.g. {@code query("SELECT * FROM table")} or {@code post("url", "body")}.
  *
  * <p>Grammar: {@code expression := name '(' ( stringLiteral (',' stringLiteral)* )? ')'}
+ *
+ * <p>This is a parsing detail of {@link io.roadrunner.samplers.spi.SamplerExtensionPoint} — the
+ * containing package is not exported by this module, so no other module can reference this type.
  */
 public record SamplerExpression(String methodName, List<String> arguments) {
 
@@ -290,9 +294,9 @@ Expected: PASS (all `SamplerExpressionTest` cases green).
 ```bash
 ./mvnw spotless:apply -pl roadrunner-samplers-spi
 git add roadrunner-samplers-spi/pom.xml \
-        roadrunner-samplers-spi/src/main/java/io/roadrunner/samplers/spi/SamplerExpression.java \
-        roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/SamplerExpressionTest.java
-git commit -m "Add SamplerExpression parser for sampler operation CLI syntax"
+        roadrunner-samplers-spi/src/main/java/io/roadrunner/samplers/spi/internal/SamplerExpression.java \
+        roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/internal/SamplerExpressionTest.java
+git commit -m "Add internal SamplerExpression parser for sampler operation CLI syntax"
 ```
 
 ---
@@ -304,12 +308,12 @@ git commit -m "Add SamplerExpression parser for sampler operation CLI syntax"
 - Test: `roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/SamplerExtensionPointTest.java`
 
 **Interfaces:**
-- Consumes: `SamplerExpression` (Task 1) — `methodName()`, `arguments()`. `io.roadrunner.api.samplers.Sampler` (existing, single abstract method `execute(SamplerParameters)`). `io.roadrunner.samplers.spi.PluginInitializationException` (existing, `roadrunner-samplers-spi`, constructor `(String message, Throwable cause)`).
-- Produces: `final class SamplerExtensionPoint` with `static Supplier<Sampler> bind(Object target, SamplerExpression expression)`. Consumed by `JDBCSamplerProvider`/`Neo4jSamplerProvider` in Tasks 3–4.
+- Consumes: `io.roadrunner.samplers.spi.internal.SamplerExpression` (Task 1, same module — `SamplerExtensionPoint` is the only caller anywhere). `io.roadrunner.api.samplers.Sampler` (existing, single abstract method `execute(SamplerParameters)`). `io.roadrunner.samplers.spi.PluginInitializationException` (existing, `roadrunner-samplers-spi`, constructor `(String message, Throwable cause)`).
+- Produces: `final class SamplerExtensionPoint` with `static Supplier<Sampler> bind(Object target, String expressionText)` — the module's only exported entry point for this mechanism; the parsed IR type never appears in this signature. Consumed by `JDBCSamplerProvider`/`Neo4jSamplerProvider` in Tasks 3–4.
 
 - [ ] **Step 1: Write the failing test**
 
-Create `roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/SamplerExtensionPointTest.java`:
+Create `roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/SamplerExtensionPointTest.java`. Note this test never imports `SamplerExpression` — it exercises `bind` exactly the way `JDBCSamplerProvider`/`Neo4jSamplerProvider` will, with a raw string:
 
 ```java
 /**
@@ -364,10 +368,9 @@ class SamplerExtensionPointTest {
 
     @Test
     void bindsSingleArgumentMethodAndPassesTheLiteral() {
-        var expression = SamplerExpression.parse("query(\"SELECT 1\")");
         var fixture = new QueryFixture();
 
-        var sampler = SamplerExtensionPoint.bind(fixture, expression).get();
+        var sampler = SamplerExtensionPoint.bind(fixture, "query(\"SELECT 1\")").get();
         var response = sampler.execute(SamplerParameters.NONE);
 
         assertThat(fixture.lastSql()).isEqualTo("SELECT 1");
@@ -376,10 +379,9 @@ class SamplerExtensionPointTest {
 
     @Test
     void bindsZeroArgumentMethodAmongMultipleCandidates() {
-        var expression = SamplerExpression.parse("noArgs()");
         var fixture = new QueryFixture();
 
-        var sampler = SamplerExtensionPoint.bind(fixture, expression).get();
+        var sampler = SamplerExtensionPoint.bind(fixture, "noArgs()").get();
         var response = sampler.execute(SamplerParameters.NONE);
 
         assertThat(response).isInstanceOf(SamplerResponse.Response.class);
@@ -387,35 +389,35 @@ class SamplerExtensionPointTest {
 
     @Test
     void eachSupplierInvocationProducesAFreshSampler() {
-        var expression = SamplerExpression.parse("query(\"SELECT 1\")");
-        var samplerSupplier = SamplerExtensionPoint.bind(new QueryFixture(), expression);
+        var samplerSupplier = SamplerExtensionPoint.bind(new QueryFixture(), "query(\"SELECT 1\")");
 
         assertThat(samplerSupplier.get()).isNotSameAs(samplerSupplier.get());
     }
 
     @Test
-    void unknownMethodNameThrows() {
-        var expression = SamplerExpression.parse("update(\"SELECT 1\")");
+    void malformedExpressionThrows() {
+        assertThatThrownBy(() -> SamplerExtensionPoint.bind(new QueryFixture(), "query(\"unterminated"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unterminated string literal");
+    }
 
-        assertThatThrownBy(() -> SamplerExtensionPoint.bind(new QueryFixture(), expression))
+    @Test
+    void unknownMethodNameThrows() {
+        assertThatThrownBy(() -> SamplerExtensionPoint.bind(new QueryFixture(), "update(\"SELECT 1\")"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("update");
     }
 
     @Test
     void arityMismatchThrows() {
-        var expression = SamplerExpression.parse("query(\"a\", \"b\")");
-
-        assertThatThrownBy(() -> SamplerExtensionPoint.bind(new QueryFixture(), expression))
+        assertThatThrownBy(() -> SamplerExtensionPoint.bind(new QueryFixture(), "query(\"a\", \"b\")"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("query");
     }
 
     @Test
     void nonStringParameterThrows() {
-        var expression = SamplerExpression.parse("withInt(\"1\")");
-
-        assertThatThrownBy(() -> SamplerExtensionPoint.bind(new NonStringParameterFixture(), expression))
+        assertThatThrownBy(() -> SamplerExtensionPoint.bind(new NonStringParameterFixture(), "withInt(\"1\")"))
                 .isInstanceOf(PluginInitializationException.class)
                 .hasMessageContaining("withInt");
     }
@@ -450,6 +452,7 @@ Create `roadrunner-samplers-spi/src/main/java/io/roadrunner/samplers/spi/Sampler
 package io.roadrunner.samplers.spi;
 
 import io.roadrunner.api.samplers.Sampler;
+import io.roadrunner.samplers.spi.internal.SamplerExpression;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
@@ -459,8 +462,10 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
- * Binds a parsed {@link SamplerExpression} to a matching {@code Sampler}-returning method on a
- * target object, producing a factory for the resulting {@link Sampler}.
+ * Binds a sampler operation expression (e.g. {@code query("SELECT 1")}) to a matching
+ * {@code Sampler}-returning method on a target object, producing a factory for the resulting
+ * {@link Sampler}. This is the module's only exported entry point for the mechanism — callers
+ * pass the raw expression text and never see the parsed intermediate representation.
  *
  * <p>Uses {@link MethodHandles#publicLookup()} rather than {@link MethodHandles#lookup()}: the
  * target class typically lives in a different Maven/JPMS module than this class, and this module
@@ -470,7 +475,9 @@ public final class SamplerExtensionPoint {
 
     private SamplerExtensionPoint() {}
 
-    public static Supplier<Sampler> bind(Object target, SamplerExpression expression) {
+    public static Supplier<Sampler> bind(Object target, String expressionText) {
+        SamplerExpression expression = SamplerExpression.parse(expressionText);
+
         List<Method> candidates = candidateMethods(target.getClass());
 
         List<Method> matching = candidates.stream()
@@ -562,7 +569,7 @@ Expected: PASS (all `SamplerExtensionPointTest` cases green).
 ./mvnw spotless:apply -pl roadrunner-samplers-spi
 git add roadrunner-samplers-spi/src/main/java/io/roadrunner/samplers/spi/SamplerExtensionPoint.java \
         roadrunner-samplers-spi/src/test/java/io/roadrunner/samplers/spi/SamplerExtensionPointTest.java
-git commit -m "Add SamplerExtensionPoint: MethodHandle-bind a parsed expression to a Sampler factory"
+git commit -m "Add SamplerExtensionPoint: MethodHandle-bind an expression to a Sampler factory"
 ```
 
 ---
@@ -572,14 +579,15 @@ git commit -m "Add SamplerExtensionPoint: MethodHandle-bind a parsed expression 
 **Files:**
 - Create: `roadrunner-sampler-jdbc/src/main/java/io/roadrunner/samplers/jdbc/JDBCSampler.java`
 - Modify: `roadrunner-sampler-jdbc/src/main/java/io/roadrunner/samplers/jdbc/JDBCSamplerProvider.java`
-- Modify: `roadrunner-sampler-jdbc/src/main/java/io/roadrunner/samplers/jdbc/JDBCSamplerPlugin.java:47` (the `new JDBCSamplerProvider(dataSource, options.query)` line)
-- Modify: `roadrunner-sampler-jdbc/src/it/java/io/roadrunner/samplers/jdbc/tests/JDBCSamplerProviderIT.java:201-209` (`defaultSamplerOptions` helper)
+- Modify: `roadrunner-sampler-jdbc/src/it/java/io/roadrunner/samplers/jdbc/tests/JDBCSamplerProviderIT.java`
 
 **Interfaces:**
-- Consumes: `SamplerExpression.parse(String)` (Task 1), `SamplerExtensionPoint.bind(Object, SamplerExpression)` (Task 2).
-- Produces: `JDBCSampler` with `Sampler query(String sql)`, `long sampleCount()`, `long totalAcquireNanos()`, `long totalQueryNanos()`, `Connection getConnection()`. `JDBCSamplerProvider` keeps its existing public surface — `newSampler()`, `sampleCount()`, `totalAcquireNanos()`, `totalQueryNanos()`, `close()`, `getConnection()`, plus a new `(DataSource, SamplerExpression)` constructor alongside the existing `(DataSource, String)` one.
+- Consumes: `SamplerExtensionPoint.bind(Object, String)` (Task 2).
+- Produces: `JDBCSampler` with `Sampler query(String sql)`, `long sampleCount()`, `long totalAcquireNanos()`, `long totalQueryNanos()`, `Connection getConnection()`. `JDBCSamplerProvider` keeps its existing public surface — `newSampler()`, `sampleCount()`, `totalAcquireNanos()`, `totalQueryNanos()`, `close()`, `getConnection()`, and its existing `(DataSource, String)` constructor, whose `String` now always means a full expression (`query("...")`) rather than bare SQL.
 
-No new module-info changes: `roadrunner-sampler-jdbc`'s `module-info.java` already has `requires io.roadrunner.samplers.spi;` and `exports io.roadrunner.samplers.jdbc;` (unconditional), which is everything `MethodHandles.publicLookup()` needs.
+**No changes to `JDBCSamplerPlugin.java`.** Its `newSamplerProvider` method already calls `new JDBCSamplerProvider(dataSource, options.query)` — that line is untouched; only what the `String` means changes (bare SQL → expression), which is why the IT test needs updating (next steps) but the plugin code doesn't.
+
+No new module-info changes: `roadrunner-sampler-jdbc`'s `module-info.java` already has `requires io.roadrunner.samplers.spi;` and `exports io.roadrunner.samplers.jdbc;` (unconditional), which is everything `MethodHandles.publicLookup()` needs. It has no dependency on the new internal package, and doesn't need one — it only ever calls `SamplerExtensionPoint.bind(Object, String)`.
 
 - [ ] **Step 1: Extract `JDBCSampler` — move the existing lambda body out of `JDBCSamplerProvider`**
 
@@ -758,7 +766,6 @@ package io.roadrunner.samplers.jdbc;
 
 import io.roadrunner.api.samplers.Sampler;
 import io.roadrunner.api.samplers.SamplerProvider;
-import io.roadrunner.samplers.spi.SamplerExpression;
 import io.roadrunner.samplers.spi.SamplerExtensionPoint;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -770,14 +777,9 @@ public class JDBCSamplerProvider implements SamplerProvider {
     private final JDBCSampler jdbcSampler;
     private final Supplier<Sampler> samplerSupplier;
 
-    public JDBCSamplerProvider(DataSource dataSource, String sql) {
+    public JDBCSamplerProvider(DataSource dataSource, String expressionText) {
         this.jdbcSampler = new JDBCSampler(dataSource);
-        this.samplerSupplier = () -> jdbcSampler.query(sql);
-    }
-
-    public JDBCSamplerProvider(DataSource dataSource, SamplerExpression expression) {
-        this.jdbcSampler = new JDBCSampler(dataSource);
-        this.samplerSupplier = SamplerExtensionPoint.bind(jdbcSampler, expression);
+        this.samplerSupplier = SamplerExtensionPoint.bind(jdbcSampler, expressionText);
     }
 
     @Override
@@ -808,33 +810,13 @@ public class JDBCSamplerProvider implements SamplerProvider {
 }
 ```
 
-The `(DataSource, String)` constructor is unchanged from the caller's point of view (used directly by `JDBCSamplerProviderIT.errorOnConnectionFailure`, which stays untouched) — it just builds a `JDBCSampler` internally now instead of hand-writing the lambda inline.
+The constructor's `String` parameter now always means a full expression (e.g. `query("SELECT 1")`), never bare SQL — every caller, including the direct-construction IT test (next step), passes an expression.
 
-- [ ] **Step 3: Wire the CLI-parsed expression through `JDBCSamplerPlugin`**
+- [ ] **Step 3: Update the JDBC integration test to use the new expression syntax**
 
-In `roadrunner-sampler-jdbc/src/main/java/io/roadrunner/samplers/jdbc/JDBCSamplerPlugin.java`, add the import:
+In `roadrunner-sampler-jdbc/src/it/java/io/roadrunner/samplers/jdbc/tests/JDBCSamplerProviderIT.java`:
 
-```java
-import io.roadrunner.samplers.spi.SamplerExpression;
-```
-
-And change this line inside `newSamplerProvider`:
-
-```java
-provider = new JDBCSamplerProvider(dataSource, options.query);
-```
-
-to:
-
-```java
-provider = new JDBCSamplerProvider(dataSource, SamplerExpression.parse(options.query));
-```
-
-`JDBCSamplerOptions.query` (the existing `@Parameters public String query` positional) now holds a full expression string, e.g. `query("SELECT * FROM table WHERE id = ?")`, instead of a bare SQL string. No change to `JDBCSamplerOptions.java` itself — only the meaning of the string it captures changes, which is why the IT test's helper needs to wrap the SQL in `query(...)` (next step).
-
-- [ ] **Step 4: Update the JDBC integration test to use the new expression syntax**
-
-In `roadrunner-sampler-jdbc/src/it/java/io/roadrunner/samplers/jdbc/tests/JDBCSamplerProviderIT.java`, change the `defaultSamplerOptions` helper:
+First, change the `defaultSamplerOptions` helper so every test that goes through `JDBCSamplerOptions`/`JDBCSamplerPlugin` keeps passing bare SQL to the helper, which now wraps it:
 
 ```java
 private static JDBCSamplerOptions defaultSamplerOptions(JDBCSamplerPlugin plugin, String url, String query) {
@@ -848,20 +830,41 @@ private static JDBCSamplerOptions defaultSamplerOptions(JDBCSamplerPlugin plugin
 }
 ```
 
-(Only the `options.query = query;` line changes to `options.query = "query(\"%s\")".formatted(query);` — every caller of this helper keeps passing bare SQL and is unaffected.) `errorOnConnectionFailure`, which constructs `new JDBCSamplerProvider(failingDataSource, "SELECT 1")` directly (bypassing options/plugin entirely), needs no change — it already uses the untouched `(DataSource, String)` constructor.
+Second, `errorOnConnectionFailure` constructs a `JDBCSamplerProvider` directly, bypassing options/plugin entirely — since the constructor's `String` now always means an expression, update the literal it passes:
 
-- [ ] **Step 5: Run unit and integration tests to verify they pass**
+```java
+@Test
+void errorOnConnectionFailure() {
+    var failingDataSource = new ExceptionThrowingDataSource();
+    try (var provider = new JDBCSamplerProvider(failingDataSource, "query(\"SELECT 1\")");
+         var sampler = provider.newSampler()) {
+        var response = sampler.execute(SamplerParameters.NONE);
+        assertThat(response)
+                .asInstanceOf(type(SamplerResponse.Error.class))
+                .satisfies(r -> {
+                    assertThat(r.timestamp()).isGreaterThan(0);
+                    assertThat(r.stopTime()).isGreaterThan(r.timestamp());
+                    assertThat(r.message()).isEqualTo("simulated connection failure");
+                });
+        assertThat(provider.sampleCount()).isEqualTo(1);
+        assertThat(provider.totalAcquireNanos()).isPositive();
+    }
+}
+```
+
+(Only the string literal `"SELECT 1"` → `"query(\"SELECT 1\")"` changes; the rest of the test is identical. `provider.sampleCount()`/`totalAcquireNanos()` still work because `JDBCSample.query("SELECT 1")`'s returned `Sampler` still records timings on the same `JDBCSampler` instance whether it's constructed by hand or through the extension point.)
+
+- [ ] **Step 4: Run unit and integration tests to verify they pass**
 
 Run: `./mvnw -pl roadrunner-sampler-jdbc -am verify`
 Expected: PASS — all `JDBCSamplerProviderIT` cases green (uses the hsqldb driver copied into `target/jdbc-drivers` by the `pre-integration-test` phase already configured in the module's `pom.xml`).
 
-- [ ] **Step 6: Format and commit**
+- [ ] **Step 5: Format and commit**
 
 ```bash
 ./mvnw spotless:apply -pl roadrunner-sampler-jdbc
 git add roadrunner-sampler-jdbc/src/main/java/io/roadrunner/samplers/jdbc/JDBCSampler.java \
         roadrunner-sampler-jdbc/src/main/java/io/roadrunner/samplers/jdbc/JDBCSamplerProvider.java \
-        roadrunner-sampler-jdbc/src/main/java/io/roadrunner/samplers/jdbc/JDBCSamplerPlugin.java \
         roadrunner-sampler-jdbc/src/it/java/io/roadrunner/samplers/jdbc/tests/JDBCSamplerProviderIT.java
 git commit -m "Migrate JDBC sampler onto the SamplerExtensionPoint mechanism"
 ```
@@ -873,14 +876,15 @@ git commit -m "Migrate JDBC sampler onto the SamplerExtensionPoint mechanism"
 **Files:**
 - Create: `roadrunner-sampler-neo4j/src/main/java/io/roadrunner/samplers/neo4j/Neo4jSampler.java`
 - Modify: `roadrunner-sampler-neo4j/src/main/java/io/roadrunner/samplers/neo4j/Neo4jSamplerProvider.java`
-- Modify: `roadrunner-sampler-neo4j/src/main/java/io/roadrunner/samplers/neo4j/Neo4jSamplerPlugin.java:34-38`
 - Modify: `roadrunner-sampler-neo4j/src/it/java/io/roadrunner/samplers/neo4j/Neo4jSamplerPluginIT.java`
 
 **Interfaces:**
-- Consumes: `SamplerExpression.parse(String)` (Task 1), `SamplerExtensionPoint.bind(Object, SamplerExpression)` (Task 2).
-- Produces: `Neo4jSampler` with `Sampler query(String cypher)` and `void close()`. `Neo4jSamplerProvider` keeps `newSampler()`/`close()`, plus a new `(Driver, SamplerExpression)` constructor alongside the existing `(Driver, String)` one.
+- Consumes: `SamplerExtensionPoint.bind(Object, String)` (Task 2).
+- Produces: `Neo4jSampler` with `Sampler query(String cypher)` and `void close()`. `Neo4jSamplerProvider` keeps `newSampler()`/`close()` and its existing `(Driver, String)` constructor, whose `String` now always means a full expression rather than bare Cypher.
 
-No `module-info.java` changes needed (same reasoning as Task 3: `requires io.roadrunner.samplers.spi;` and unconditional `exports io.roadrunner.samplers.neo4j;` already present).
+**No changes to `Neo4jSamplerPlugin.java`.** Its `newSamplerProvider` method already calls `new Neo4jSamplerProvider(driver, options.query)` — untouched; only what the string means changes.
+
+No `module-info.java` changes needed (same reasoning as Task 3).
 
 - [ ] **Step 1: Extract `Neo4jSampler`**
 
@@ -968,7 +972,6 @@ package io.roadrunner.samplers.neo4j;
 
 import io.roadrunner.api.samplers.Sampler;
 import io.roadrunner.api.samplers.SamplerProvider;
-import io.roadrunner.samplers.spi.SamplerExpression;
 import io.roadrunner.samplers.spi.SamplerExtensionPoint;
 import java.util.function.Supplier;
 import org.neo4j.driver.Driver;
@@ -978,14 +981,9 @@ public class Neo4jSamplerProvider implements SamplerProvider {
     private final Neo4jSampler neo4jSampler;
     private final Supplier<Sampler> samplerSupplier;
 
-    public Neo4jSamplerProvider(Driver driver, String cypher) {
+    public Neo4jSamplerProvider(Driver driver, String expressionText) {
         this.neo4jSampler = new Neo4jSampler(driver);
-        this.samplerSupplier = () -> neo4jSampler.query(cypher);
-    }
-
-    public Neo4jSamplerProvider(Driver driver, SamplerExpression expression) {
-        this.neo4jSampler = new Neo4jSampler(driver);
-        this.samplerSupplier = SamplerExtensionPoint.bind(neo4jSampler, expression);
+        this.samplerSupplier = SamplerExtensionPoint.bind(neo4jSampler, expressionText);
     }
 
     @Override
@@ -1000,26 +998,7 @@ public class Neo4jSamplerProvider implements SamplerProvider {
 }
 ```
 
-- [ ] **Step 3: Wire the CLI-parsed expression through `Neo4jSamplerPlugin`**
-
-In `roadrunner-sampler-neo4j/src/main/java/io/roadrunner/samplers/neo4j/Neo4jSamplerPlugin.java`, add the import:
-
-```java
-import io.roadrunner.samplers.spi.SamplerExpression;
-```
-
-And change `newSamplerProvider`:
-
-```java
-@Override
-public Neo4jSamplerProvider newSamplerProvider(Neo4jSamplerOptions options) {
-    var driver = GraphDatabase.driver(options.uri, AuthTokens.basic(options.username, options.password));
-
-    return new Neo4jSamplerProvider(driver, SamplerExpression.parse(options.query));
-}
-```
-
-- [ ] **Step 4: Update the Neo4j integration test to use the new expression syntax**
+- [ ] **Step 3: Update the Neo4j integration test to use the new expression syntax**
 
 In `roadrunner-sampler-neo4j/src/it/java/io/roadrunner/samplers/neo4j/Neo4jSamplerPluginIT.java`, update all three tests. `invalidQuery` previously left `options.query` unset (`null`) to exercise Neo4j's own "query text should not be null" validation; with the new syntax `options.query` is now always a parseable expression (a null/missing value would fail in `SamplerExpression.parse` before ever reaching Neo4j, with a different, clearer message), so this test now exercises an *empty* cypher literal instead, and asserts only that an error surfaces (not the exact driver wording, which may differ):
 
@@ -1081,18 +1060,17 @@ void validParameterizedQuery() throws Exception {
 }
 ```
 
-- [ ] **Step 5: Run integration tests to verify they pass**
+- [ ] **Step 4: Run integration tests to verify they pass**
 
 Run: `./mvnw -pl roadrunner-sampler-neo4j -am verify`
 Expected: PASS — all `Neo4jSamplerPluginIT` cases green (requires Docker for the Neo4j Testcontainers container).
 
-- [ ] **Step 6: Format and commit**
+- [ ] **Step 5: Format and commit**
 
 ```bash
 ./mvnw spotless:apply -pl roadrunner-sampler-neo4j
 git add roadrunner-sampler-neo4j/src/main/java/io/roadrunner/samplers/neo4j/Neo4jSampler.java \
         roadrunner-sampler-neo4j/src/main/java/io/roadrunner/samplers/neo4j/Neo4jSamplerProvider.java \
-        roadrunner-sampler-neo4j/src/main/java/io/roadrunner/samplers/neo4j/Neo4jSamplerPlugin.java \
         roadrunner-sampler-neo4j/src/it/java/io/roadrunner/samplers/neo4j/Neo4jSamplerPluginIT.java
 git commit -m "Migrate Neo4j sampler onto the SamplerExtensionPoint mechanism"
 ```

--- a/docs/superpowers/specs/2026-07-13-sampler-method-extension-points-design.md
+++ b/docs/superpowers/specs/2026-07-13-sampler-method-extension-points-design.md
@@ -82,8 +82,10 @@ bind.
 
 ```
 roadrunner-samplers-spi
-  ├─ SamplerExpression   (new)  — parses "name(\"lit\", ...)" into an IR
-  └─ SamplerExtensionPoint (new) — validates + MethodHandle-binds + adapts
+  io.roadrunner.samplers.spi            (exported — public SPI surface)
+    └─ SamplerExtensionPoint (new) — validates + parses + MethodHandle-binds
+  io.roadrunner.samplers.spi.internal   (NOT exported — implementation detail)
+    └─ SamplerExpression (new) — parses "name(\"lit\", ...)" into an IR
 
            used by (construction time only)
                     │
@@ -103,17 +105,32 @@ ServiceLoader discovery, roadrunner-core's ExecutionStrategy — all unchanged.
 
 No new module. Both new types live in `roadrunner-samplers-spi`, alongside
 `SamplerOptions`/`SamplerPlugin`, since every sampler module already depends
-on it.
+on it. `SamplerExpression` is a parsing detail of *how* `SamplerExtensionPoint`
+turns a string into a bound `Sampler` — not something a sampler author (or
+any other module) ever names directly — so it lives in an unexported
+sub-package. `roadrunner-sampler-jdbc`/`roadrunner-sampler-neo4j` call only
+`SamplerExtensionPoint.bind(Object, String)`; they never import
+`SamplerExpression`, and JPMS enforces that (the package isn't `exports`-ed,
+so it's a compile error for another module to even name the type).
 
-## `SamplerExpression`
+## `SamplerExpression` (internal)
 
 ```java
-package io.roadrunner.samplers.spi;
+package io.roadrunner.samplers.spi.internal;
 
 public record SamplerExpression(String methodName, List<String> arguments) {
     public static SamplerExpression parse(String input) { ... }
 }
 ```
+
+`public` (so `SamplerExtensionPoint`, in the sibling `io.roadrunner.samplers.spi`
+package, can reference it — package-private wouldn't be visible across
+packages even within the same module), but the containing package is simply
+never named in `roadrunner-samplers-spi`'s `module-info.java`'s `exports`
+list, which is all JPMS needs to keep it invisible to every other module. No
+`module-info.java` change is required to achieve this — the module already
+only exports `io.roadrunner.samplers.spi`; a new package is unexported by
+default unless explicitly added.
 
 Grammar (intentionally minimal — only what JDBC/Neo4j need):
 
@@ -134,11 +151,21 @@ surfaced at CLI startup, before any sample is taken.
 package io.roadrunner.samplers.spi;
 
 public final class SamplerExtensionPoint {
-    public static Supplier<Sampler> bind(Object target, SamplerExpression expression) { ... }
+    public static Supplier<Sampler> bind(Object target, String expressionText) { ... }
 }
 ```
 
+This is the module's only exported entry point for the mechanism —
+`SamplerExpression` (the parsed IR) never appears in this signature, so
+callers in other modules (`JDBCSamplerPlugin`, `Neo4jSamplerPlugin`) pass
+`options.query` straight through as a `String` and never reference
+`SamplerExpression` at all.
+
 Binding steps:
+
+0. **Parse.** `SamplerExpression.parse(expressionText)` (internal package,
+   same module — see above). Parse errors propagate as the
+   `IllegalArgumentException` `SamplerExpression.parse` already throws.
 
 1. **Validate eligibility.** Scan `target.getClass().getMethods()` and
    consider only the methods whose return type is exactly `Sampler` — those
@@ -277,7 +304,7 @@ public class JDBCSampler {
 ```java
 @Override
 public Sampler newSampler() {
-    return samplerSupplier.get(); // samplerSupplier = SamplerExtensionPoint.bind(jdbcSampler, expression)
+    return samplerSupplier.get(); // samplerSupplier = SamplerExtensionPoint.bind(jdbcSampler, options.query)
 }
 ```
 
@@ -291,10 +318,12 @@ jdbc --url jdbc:postgresql://localhost/db --username u --password p \
      --driver driver.jar 'query("SELECT * FROM table WHERE id = ?")'
 ```
 
-`JDBCSamplerPlugin.newSamplerProvider` parses that string with
-`SamplerExpression.parse`, builds the `JDBCSampler` with the constructed
-`DataSource`, and calls `SamplerExtensionPoint.bind(jdbcSampler, expression)`
-once to get the `Supplier<Sampler>` handed to `JDBCSamplerProvider`.
+`JDBCSamplerPlugin.newSamplerProvider` builds the `JDBCSampler` with the
+constructed `DataSource` and calls `SamplerExtensionPoint.bind(jdbcSampler,
+options.query)` directly — passing the raw string straight through, once, to
+get the `Supplier<Sampler>` handed to `JDBCSamplerProvider`. Neither
+`JDBCSamplerPlugin` nor `JDBCSamplerProvider` ever imports `SamplerExpression`;
+parsing is entirely `SamplerExtensionPoint.bind`'s own concern.
 
 **Neo4j.** Same shape: `Neo4jSampler.query(String cypher)` returns a `Sampler`
 whose body is today's `Neo4jSamplerProvider.newSampler()` lambda (run
@@ -333,13 +362,16 @@ which is no different from today's `newSampler()` contract.
 
 - New `roadrunner-samplers-spi` test source set (none exists yet — add a
   junit dependency to its `pom.xml`, matching sibling sampler modules):
-  - `SamplerExpressionTest`: valid parses (zero/one/multiple string args),
-    malformed input (unterminated literal, missing parens, empty method
-    name).
-  - `SamplerExtensionPointTest`: successful bind + invoke round-trip against
-    a small in-test fixture class; rejection of a method with a non-`String`
-    parameter; rejection of a method returning something other than
-    `Sampler`; arity-mismatch and unknown-method-name errors.
+  - `SamplerExpressionTest` (package `io.roadrunner.samplers.spi.internal`):
+    valid parses (zero/one/multiple string args), malformed input
+    (unterminated literal, missing parens, empty method name).
+  - `SamplerExtensionPointTest` (package `io.roadrunner.samplers.spi`):
+    exercises the public `bind(Object, String)` entry point directly (never
+    imports `SamplerExpression`) — successful bind + invoke round-trip
+    against a small in-test fixture class; rejection of a method with a
+    non-`String` parameter; rejection of a method returning something other
+    than `Sampler`; arity-mismatch and unknown-method-name errors; malformed
+    expression text.
 - Existing `JDBCSamplerProviderIT` (`roadrunner-sampler-jdbc/src/it`) and
   `Neo4jSamplerPluginIT` (`roadrunner-sampler-neo4j/src/it`) continue to
   exercise the migrated samplers end-to-end (real Postgres/Neo4j) — updated

--- a/docs/superpowers/specs/2026-07-13-sampler-method-extension-points-design.md
+++ b/docs/superpowers/specs/2026-07-13-sampler-method-extension-points-design.md
@@ -363,12 +363,13 @@ which is no different from today's `newSampler()` contract.
    behaves identically to today. A sampler author who instead wants one
    shared, stateless `Sampler` can simply have their method return the same
    cached instance — the mechanism doesn't force either choice.
-3. **Ambiguous arity across overloads.** If a methods class ever declares two
-   `Sampler`-returning methods with the same name and the same parameter
-   count (e.g. two overloads both taking two `String`s), resolution in step 2
-   can't disambiguate by name + arity alone. Not a problem for JDBC/Neo4j
-   (one `Sampler`-returning method each); `PluginInitializationException` at
-   bind time if it ever occurs, rather than silently picking one.
+3. ~~Ambiguous overloads~~ — considered and ruled out: resolution in step 2
+   matches by name *and* arity, and since every candidate parameter must be
+   `String` (step 1), two `Sampler`-returning methods with the same name and
+   same arity would necessarily have identical parameter types — which Java
+   itself rejects as a duplicate method at compile time. Name + arity
+   matching is therefore always unambiguous; no defensive "which one did you
+   mean" code is needed in `SamplerExtensionPoint`.
 
 ## Open questions (deferred to the implementation plan)
 
@@ -377,7 +378,7 @@ which is no different from today's `newSampler()` contract.
 - Whether `SamplerExpression`'s grammar should reject or silently accept
   extra whitespace around literals/commas — lean toward accepting it, to be
   decided during implementation.
-- Whether a shared helper for "bui`ld a `DataSource`-backed methods class + a
+- Whether a shared helper for "build a `DataSource`-backed methods class + a
   `SamplerProvider` that delegates to `SamplerExtensionPoint`" is worth
   factoring out once a third sampler adopts this pattern. Not needed for two
   samplers — revisit if a third migration arrives.

--- a/docs/superpowers/specs/2026-07-13-sampler-method-extension-points-design.md
+++ b/docs/superpowers/specs/2026-07-13-sampler-method-extension-points-design.md
@@ -140,16 +140,18 @@ public final class SamplerExtensionPoint {
 
 Binding steps:
 
-1. **Validate eligibility.** Every public method declared on `target`'s class
-   (excluding anything inherited from `Object`/`AutoCloseable`) must:
-   - return exactly `Sampler`,
-   - take only `String` parameters (the only literal type supported today).
-
-   Validation runs over *all* public methods up front, not just the one
-   matching the expression's method name — a badly-shaped method on a
-   sampler class fails at plugin construction time regardless of which
-   operation the CLI expression picked. Violations throw
-   `PluginInitializationException` naming the offending method and why.
+1. **Validate eligibility.** Scan `target.getClass().getMethods()` and
+   consider only the methods whose return type is exactly `Sampler` — those
+   are the extension-point candidates. (This is narrower than the original
+   draft of this section, which said *every* public method must qualify;
+   that broke on `JDBCSampler` itself, which also needs plain accessor
+   methods like `sampleCount()` for `JDBCSamplerPlugin`'s summary log.
+   Methods that don't return `Sampler` are simply outside the extension
+   point's concern and are left alone — no rejection, no annotation needed
+   to hide them.) Each candidate method's parameters must all be `String`
+   (the only literal type supported today); a candidate with a non-`String`
+   parameter throws `PluginInitializationException` naming the offending
+   method and why, at plugin construction time.
 
 2. **Resolve.** Find the method named `expression.methodName()` whose
    parameter count equals `expression.arguments().size()`. No match (wrong
@@ -355,12 +357,12 @@ which is no different from today's `newSampler()` contract.
    behaves identically to today. A sampler author who instead wants one
    shared, stateless `Sampler` can simply have their method return the same
    cached instance — the mechanism doesn't force either choice.
-3. **Validation false positives.** Scanning *all* public methods (not just
-   the invoked one) means a sampler class must keep every public method
-   extension-point-eligible, or explicitly keep helper methods
-   package-private/private. This is documented behavior, not a defect, but
-   worth calling out clearly in Javadoc on the methods class so authors don't
-   trip over it.
+3. **Ambiguous arity across overloads.** If a methods class ever declares two
+   `Sampler`-returning methods with the same name and the same parameter
+   count (e.g. two overloads both taking two `String`s), resolution in step 2
+   can't disambiguate by name + arity alone. Not a problem for JDBC/Neo4j
+   (one `Sampler`-returning method each); `PluginInitializationException` at
+   bind time if it ever occurs, rather than silently picking one.
 
 ## Open questions (deferred to the implementation plan)
 

--- a/docs/superpowers/specs/2026-07-13-sampler-method-extension-points-design.md
+++ b/docs/superpowers/specs/2026-07-13-sampler-method-extension-points-design.md
@@ -1,0 +1,301 @@
+# Sampler Method Extension Points
+
+Date: 2026-07-13
+Status: Approved (design); implementation plan to follow
+Issue: [#101](https://github.com/symentispl/roadrunner/issues/101)
+
+## Context
+
+`Sampler` (`roadrunner-api`) is a single-method functional interface:
+
+```java
+public interface Sampler extends AutoCloseable {
+    SamplerResponse<?> execute(SamplerParameters parameters);
+    default void close() {}
+}
+```
+
+Every sampler today — JDBC, Neo4j, AB (HTTP), VM — models its one operation
+(a fixed query, a fixed HTTP request, a sleep) as this single `execute` entry
+point, built once by `SamplerProvider.newSampler()`. `SamplerParameters` is an
+ordered bag whose interpretation each sampler invents for itself (JDBC binds
+values positionally to `?` placeholders; Neo4j passes the whole map by name;
+AB currently ignores it — the request is fixed at construction).
+
+This works because no existing sampler needs more than one operation. It
+breaks down for protocols with a natural set of distinct operations (an HTTP
+sampler's `GET`/`POST`/`PUT`, a JDBC sampler that might want `query` versus
+`update`) — today those would have to be jammed into flags (`-m GET`) or
+separate CLI subcommands, with no type-checked parameter list of their own.
+
+Issue #101 proposes letting a sampler expose its own named methods (e.g.
+`JDBCSampler.query(String sql)`) and have a small CLI expression
+(`query("SELECT * FROM table")`) parsed and bound, via `MethodHandle`s, to the
+matching method — producing an ordinary `Sampler` that plugs into the
+existing engine unchanged.
+
+`Sampler.execute()` is on the hot path (called every iteration by
+`OpenWorldStrategy`/`ClosedWorldStrategy`), which is why the issue calls for
+`MethodHandle`s rather than reflection (`Method.invoke`) for the one-time
+bind.
+
+## Goals
+
+1. Let a sampler class expose multiple named operations instead of one fixed
+   `execute()`, each with its own typed parameter list.
+2. A small CLI expression syntax — `methodName("literal", "literal", ...)` —
+   selects the operation and supplies its literal arguments, parsed and bound
+   once per sampler setup (not per request).
+3. The binder produces a standard `Sampler` instance; nothing downstream
+   (`SamplerProvider`, `SamplerPlugin`, `ExecutionStrategy`, picocli wiring,
+   JPMS `ServiceLoader` discovery) changes.
+4. Both mechanisms coexist permanently: a sampler can keep implementing
+   `Sampler`/`SamplerProvider` directly for simple, single-operation cases
+   (AB, VM stay this way), or expose named methods for richer cases (JDBC,
+   Neo4j migrate to this as the worked examples).
+5. Per-request parameter binding (`SamplerParameters` → `?` placeholders,
+   named map, etc.) is unchanged — it still happens inside the `Sampler`
+   returned by an extension-point method, exactly as it does today inside
+   `SamplerProvider.newSampler()`'s hand-written lambda.
+
+## Non-Goals
+
+- No per-request/dynamic values in the CLI expression. Arguments are literal
+  strings, resolved once at sampler setup — never sourced from a
+  `ParameterSource` row. (Confirmed with the issue author: the framework-bound
+  value is `SamplerParameters`, and that binding continues to happen exactly
+  where it happens today — inside the returned `Sampler`'s `execute` body —
+  not as an extension-point method parameter.)
+- No migration of AB or VM samplers. They keep implementing `Sampler`
+  directly, demonstrating that the simple path still works.
+- No literal argument types beyond `String` in this change. Neither JDBC nor
+  Neo4j need numeric/`URL`/file-content (`@File`) literals; the converter
+  point is a single, obvious extension seam for later.
+- No new Maven module and no new external dependency (parser generator,
+  reflection library). `MethodHandle`/`MethodHandleProxies` are JDK stdlib;
+  the hand-rolled parser follows the existing precedent of `PrefixedMap` in
+  `roadrunner-cli`.
+- No change to `SamplerParameters`, `ParameterSource`, `ParameterFeed`, or any
+  `ExecutionStrategy`.
+
+## Architecture
+
+```
+roadrunner-samplers-spi
+  ├─ SamplerExpression   (new)  — parses "name(\"lit\", ...)" into an IR
+  └─ SamplerExtensionPoint (new) — validates + MethodHandle-binds + adapts
+
+           used by (construction time only)
+                    │
+                    ▼
+roadrunner-sampler-jdbc / roadrunner-sampler-neo4j
+  ├─ JDBCSampler / Neo4jSampler   (new "methods" classes)
+  └─ JDBCSamplerProvider / Neo4jSamplerProvider  (unchanged shape: still
+     implement SamplerProvider.newSampler(), now delegating to the bound
+     factory instead of hand-building the Sampler lambda inline)
+
+roadrunner-sampler-ab / roadrunner-sampler-vm — untouched, still implement
+Sampler/SamplerProvider directly.
+
+roadrunner-cli, roadrunner-samplers-spi's SamplerPlugin/SamplerOptions/JPMS
+ServiceLoader discovery, roadrunner-core's ExecutionStrategy — all unchanged.
+```
+
+No new module. Both new types live in `roadrunner-samplers-spi`, alongside
+`SamplerOptions`/`SamplerPlugin`, since every sampler module already depends
+on it.
+
+## `SamplerExpression`
+
+```java
+package io.roadrunner.samplers.spi;
+
+public record SamplerExpression(String methodName, List<String> arguments) {
+    public static SamplerExpression parse(String input) { ... }
+}
+```
+
+Grammar (intentionally minimal — only what JDBC/Neo4j need):
+
+```
+expression := name '(' ( stringLiteral (',' stringLiteral)* )? ')'
+name       := letter (letter | digit)*
+stringLiteral := '"' (escaped-char | non-quote-char)* '"'
+```
+
+Implementation follows `PrefixedMap.parse`'s hand-rolled character-state-machine
+style (no parser-generator dependency). Malformed input throws
+`IllegalArgumentException` with a message naming the offending position —
+surfaced at CLI startup, before any sample is taken.
+
+## `SamplerExtensionPoint`
+
+```java
+package io.roadrunner.samplers.spi;
+
+public final class SamplerExtensionPoint {
+    public static Supplier<Sampler> bind(Object target, SamplerExpression expression) { ... }
+}
+```
+
+Binding steps:
+
+1. **Validate eligibility.** Every public method declared on `target`'s class
+   (excluding anything inherited from `Object`/`AutoCloseable`) must:
+   - return exactly `Sampler`,
+   - take only `String` parameters (the only literal type supported today).
+
+   Validation runs over *all* public methods up front, not just the one
+   matching the expression's method name — a badly-shaped method on a
+   sampler class fails at plugin construction time regardless of which
+   operation the CLI expression picked. Violations throw
+   `PluginInitializationException` naming the offending method and why.
+
+2. **Resolve.** Find the method named `expression.methodName()` whose
+   parameter count equals `expression.arguments().size()`. No match (wrong
+   name or wrong arity) throws `IllegalArgumentException` listing the
+   available methods and their arities.
+
+3. **Bind.** `MethodHandles.lookup().unreflect(method)` → `MethodHandle` with
+   receiver as the leading parameter; `MethodHandles.insertArguments` binds
+   `target` plus every literal argument, fully saturating the handle (zero
+   parameters remain).
+
+4. **Wrap.** Return `() -> { try { return (Sampler) handle.invoke(); } catch (Throwable t) { throw ...; } }`.
+   Each invocation of the returned `Supplier<Sampler>` calls the fully-bound
+   handle again, producing a fresh `Sampler` — this mirrors what
+   `SamplerProvider.newSampler()` already does today for JDBC/Neo4j/AB (build
+   a fresh instance per call) and requires no thread-safety assumptions from
+   the sampler author about a shared instance.
+
+Binding (steps 1–3) happens once, when the `SamplerProvider` is constructed.
+Step 4's `Supplier` is invoked once per `SamplerProvider.newSampler()` call
+(once per virtual thread), same call frequency as today.
+
+## Migration: JDBC and Neo4j
+
+**JDBC.** New `JDBCSampler` class:
+
+```java
+public class JDBCSampler {
+    private final DataSource dataSource;
+    public JDBCSampler(DataSource dataSource) { this.dataSource = dataSource; }
+
+    public Sampler query(String sql) {
+        return (SamplerParameters parameters) -> {
+            // identical body to today's JDBCSamplerProvider.newSampler() lambda:
+            // acquire connection, prepareStatement(sql), bind parameters
+            // positionally to '?' placeholders, execute, record timings.
+        };
+    }
+}
+```
+
+`JDBCSamplerProvider.newSampler()` becomes:
+
+```java
+@Override
+public Sampler newSampler() {
+    return samplerSupplier.get(); // samplerSupplier = SamplerExtensionPoint.bind(jdbcSampler, expression)
+}
+```
+
+`JDBCSamplerOptions` keeps `--url/--username/--password/--driver/--driver-class
+/--pool-size` exactly as-is (infra config is orthogonal to the issue). Only
+the existing `@Parameters public String query` positional argument changes
+shape: instead of a bare SQL string, it captures a full expression, e.g.
+
+```
+jdbc --url jdbc:postgresql://localhost/db --username u --password p \
+     --driver driver.jar 'query("SELECT * FROM table WHERE id = ?")'
+```
+
+`JDBCSamplerPlugin.newSamplerProvider` parses that string with
+`SamplerExpression.parse`, builds the `JDBCSampler` with the constructed
+`DataSource`, and calls `SamplerExtensionPoint.bind(jdbcSampler, expression)`
+once to get the `Supplier<Sampler>` handed to `JDBCSamplerProvider`.
+
+**Neo4j.** Same shape: `Neo4jSampler.query(String cypher)` returns a `Sampler`
+whose body is today's `Neo4jSamplerProvider.newSampler()` lambda (run
+`cypher` against a session, passing `parameters.asMap()`), wired the same way
+through `Neo4jSamplerPlugin`.
+
+Runtime behavior for both is unchanged — same connection/session handling,
+same per-request parameter binding, same metrics. Only the wiring from CLI
+string to bound method changes.
+
+## AB and VM — unchanged
+
+Both keep implementing `Sampler`/`SamplerProvider` directly, proving the
+simple, single-operation path remains fully supported. No code in either
+module changes as part of this issue.
+
+## Error handling
+
+All new failure modes are structural and caught before any sample is taken:
+
+- Parse errors (`SamplerExpression.parse`) → `IllegalArgumentException` at
+  CLI argument parsing (surfaces the same way picocli option errors do
+  today).
+- Validation errors (ineligible method signature) → `PluginInitializationException`
+  at `SamplerPlugin.newSamplerProvider(...)` time — same exception type
+  `JDBCSamplerPlugin` already throws for driver-loading failures.
+- Resolution errors (no matching method / arity mismatch) →
+  `IllegalArgumentException` listing the sampler's available methods.
+
+No new exception type reaches `ExecutionStrategy` or the hot loop; the
+`Supplier<Sampler>` returned by `bind()` only re-throws if the *target
+method's own body* throws when invoked (e.g. a constructor-like failure),
+which is no different from today's `newSampler()` contract.
+
+## Testing
+
+- New `roadrunner-samplers-spi` test source set (none exists yet — add a
+  junit dependency to its `pom.xml`, matching sibling sampler modules):
+  - `SamplerExpressionTest`: valid parses (zero/one/multiple string args),
+    malformed input (unterminated literal, missing parens, empty method
+    name).
+  - `SamplerExtensionPointTest`: successful bind + invoke round-trip against
+    a small in-test fixture class; rejection of a method with a non-`String`
+    parameter; rejection of a method returning something other than
+    `Sampler`; arity-mismatch and unknown-method-name errors.
+- Existing `JDBCSamplerProviderIT` (`roadrunner-sampler-jdbc/src/it`) and
+  `Neo4jSamplerPluginIT` (`roadrunner-sampler-neo4j/src/it`) continue to
+  exercise the migrated samplers end-to-end (real Postgres/Neo4j) — updated
+  only to pass the new `query("...")` expression syntax instead of a bare SQL
+  string, asserting identical behavior to before the migration.
+
+## Risks
+
+1. **`MethodHandleProxies`/`unreflect` under JPMS.** Each sampler module is a
+   named module with explicit `exports`; reflective access via
+   `MethodHandles.lookup()` from within `roadrunner-samplers-spi` calling
+   into `JDBCSampler` (a different module) requires that module to `open` or
+   `exports` the package to `roadrunner-samplers-spi`, similar to the
+   existing `opens ... to info.picocli` directives already present in each
+   sampler module's `module-info.java`. Verified case-by-case during
+   implementation.
+2. **Shared vs. fresh `Sampler` per thread.** Steps 3–4 re-invoke the fully
+   bound handle on every `Supplier.get()` call, so a naive `query(String
+   sql)` implementation that allocates per call (as JDBC/Neo4j already do)
+   behaves identically to today. A sampler author who instead wants one
+   shared, stateless `Sampler` can simply have their method return the same
+   cached instance — the mechanism doesn't force either choice.
+3. **Validation false positives.** Scanning *all* public methods (not just
+   the invoked one) means a sampler class must keep every public method
+   extension-point-eligible, or explicitly keep helper methods
+   package-private/private. This is documented behavior, not a defect, but
+   worth calling out clearly in Javadoc on the methods class so authors don't
+   trip over it.
+
+## Open questions (deferred to the implementation plan)
+
+- Exact wording/format of validation and resolution error messages (how much
+  detail to include about available methods/arities).
+- Whether `SamplerExpression`'s grammar should reject or silently accept
+  extra whitespace around literals/commas — lean toward accepting it, to be
+  decided during implementation.
+- Whether a shared helper for "build a `DataSource`-backed methods class + a
+  `SamplerProvider` that delegates to `SamplerExtensionPoint`" is worth
+  factoring out once a third sampler adopts this pattern. Not needed for two
+  samplers — revisit if a third migration arrives.

--- a/docs/superpowers/specs/2026-07-13-sampler-method-extension-points-design.md
+++ b/docs/superpowers/specs/2026-07-13-sampler-method-extension-points-design.md
@@ -172,6 +172,77 @@ Binding (steps 1–3) happens once, when the `SamplerProvider` is constructed.
 Step 4's `Supplier` is invoked once per `SamplerProvider.newSampler()` call
 (once per virtual thread), same call frequency as today.
 
+Note what this means for the hot path: the `MethodHandle` is only ever
+invoked from step 4, i.e. once per virtual thread at startup. The object it
+returns (e.g. the lambda inside `JDBCSampler.query(String sql)`) is an
+ordinary, hand-written `Sampler` implementation — `execute(SamplerParameters)`
+itself is called through plain interface dispatch, exactly as it is today.
+No `MethodHandle` sits on the per-request path.
+
+## Microbenchmarks
+
+The open question is therefore narrower than "does MethodHandle dispatch
+slow down sampling" (it doesn't touch the per-request path at all) — it's
+"does binding+invoking the factory method through a `MethodHandle` cost
+meaningfully more than calling it directly, at the frequency `newSampler()`
+is actually called (once per virtual thread)?" The issue also explicitly
+motivates the `MethodHandle` choice by contrast with reflection, which is
+worth measuring rather than asserting.
+
+Add benchmarks to the existing `roadrunner-microbenchmarks` JMH module (no
+new module, no new dependency — `jmh-core` is already there) comparing three
+ways of turning a resolved target + literal argument into a `Sampler`:
+
+1. **Direct** — baseline: call `fixture.query(sql)` as an ordinary Java method
+   call (today's status quo — no indirection at all).
+2. **MethodHandle** — the design above: `Lookup.unreflect` + `insertArguments`
+   done once in `@Setup`, then `handle.invoke()` per benchmark invocation.
+3. **Reflection** — `Class.getMethod` done once in `@Setup`, then
+   `method.invoke(fixture, sql)` per benchmark invocation (Approach B from
+   this spec, included so its rejection is backed by a number, not just an
+   assertion).
+
+```java
+@State(Scope.Benchmark)
+public class SamplerFactoryDispatchState {
+    JDBCSamplerFixture fixture;   // trivial stand-in, no real DataSource needed
+    String sql;
+    MethodHandle boundHandle;     // fully saturated: unreflect + insertArguments
+    Method reflectMethod;
+
+    @Setup(Level.Trial)
+    public void setUp() throws Exception { ... }
+}
+
+@Benchmark
+public Sampler directDispatch(SamplerFactoryDispatchState s) {
+    return s.fixture.query(s.sql);
+}
+
+@Benchmark
+public Sampler methodHandleDispatch(SamplerFactoryDispatchState s) throws Throwable {
+    return (Sampler) s.boundHandle.invoke();
+}
+
+@Benchmark
+public Sampler reflectionDispatch(SamplerFactoryDispatchState s) throws Exception {
+    return (Sampler) s.reflectMethod.invoke(s.fixture, s.sql);
+}
+```
+
+JMH auto-blackholes the returned `Sampler`, so no manual `Blackhole` plumbing
+is needed. Runs through the existing `benchmarks/` tracking scripts
+(`task benchmark:run`) like the current `RoadrunnerBenchmarks` — no new
+tooling. This is a one-time comparison to sanity-check the design choice, not
+a regression gate: `newSampler()` runs once per virtual thread, so even a
+measurable per-call delta here is orders of magnitude below anything that
+would show up in end-to-end throughput.
+
+If the numbers show the `MethodHandle` path is unexpectedly costly relative
+to direct dispatch, the fallback is to cache/reuse resolved handles more
+aggressively — not to abandon `MethodHandle`s for `Method.invoke`, which the
+benchmark is expected to show is worse, not better.
+
 ## Migration: JDBC and Neo4j
 
 **JDBC.** New `JDBCSampler` class:
@@ -264,6 +335,9 @@ which is no different from today's `newSampler()` contract.
   exercise the migrated samplers end-to-end (real Postgres/Neo4j) — updated
   only to pass the new `query("...")` expression syntax instead of a bare SQL
   string, asserting identical behavior to before the migration.
+- The JMH microbenchmarks described above (direct vs `MethodHandle` vs
+  reflection dispatch) — a one-time design sanity check, run manually via
+  `task benchmark:run`, not part of the regular unit/integration test suite.
 
 ## Risks
 

--- a/docs/superpowers/specs/2026-07-13-sampler-method-extension-points-design.md
+++ b/docs/superpowers/specs/2026-07-13-sampler-method-extension-points-design.md
@@ -158,10 +158,18 @@ Binding steps:
    name or wrong arity) throws `IllegalArgumentException` listing the
    available methods and their arities.
 
-3. **Bind.** `MethodHandles.lookup().unreflect(method)` → `MethodHandle` with
-   receiver as the leading parameter; `MethodHandles.insertArguments` binds
-   `target` plus every literal argument, fully saturating the handle (zero
-   parameters remain).
+3. **Bind.** `MethodHandles.publicLookup().unreflect(method)` → `MethodHandle`
+   with receiver as the leading parameter; `MethodHandles.insertArguments`
+   binds `target` plus every literal argument, fully saturating the handle
+   (zero parameters remain). `publicLookup()`, not `lookup()`: the target
+   class (e.g. `JDBCSampler`) lives in a different module than
+   `SamplerExtensionPoint`, and `roadrunner-samplers-spi` must not gain a
+   `requires` edge back onto every sampler module that uses it — that would
+   invert the plugin dependency direction. `publicLookup()` resolves public
+   members of unconditionally-exported packages across module boundaries
+   without either module needing a `requires` on the other, which is exactly
+   the shape here (`query` is `public` on a `public` class in a package each
+   sampler module already `exports` unconditionally).
 
 4. **Wrap.** Return `() -> { try { return (Sampler) handle.invoke(); } catch (Throwable t) { throw ...; } }`.
    Each invocation of the returned `Supplier<Sampler>` calls the fully-bound
@@ -343,14 +351,12 @@ which is no different from today's `newSampler()` contract.
 
 ## Risks
 
-1. **`MethodHandleProxies`/`unreflect` under JPMS.** Each sampler module is a
-   named module with explicit `exports`; reflective access via
-   `MethodHandles.lookup()` from within `roadrunner-samplers-spi` calling
-   into `JDBCSampler` (a different module) requires that module to `open` or
-   `exports` the package to `roadrunner-samplers-spi`, similar to the
-   existing `opens ... to info.picocli` directives already present in each
-   sampler module's `module-info.java`. Verified case-by-case during
-   implementation.
+1. **Cross-module reflection under JPMS.** Resolved by using
+   `MethodHandles.publicLookup()` (see the Bind step above) rather than
+   `MethodHandles.lookup()` — no new `requires`/`opens` directives needed in
+   any `module-info.java`, since target classes are `public` in packages each
+   sampler module already `exports` unconditionally. Confirmed during
+   implementation by the extension-point unit tests actually running.
 2. **Shared vs. fresh `Sampler` per thread.** Steps 3–4 re-invoke the fully
    bound handle on every `Supplier.get()` call, so a naive `query(String
    sql)` implementation that allocates per call (as JDBC/Neo4j already do)
@@ -371,7 +377,7 @@ which is no different from today's `newSampler()` contract.
 - Whether `SamplerExpression`'s grammar should reject or silently accept
   extra whitespace around literals/commas — lean toward accepting it, to be
   decided during implementation.
-- Whether a shared helper for "build a `DataSource`-backed methods class + a
+- Whether a shared helper for "bui`ld a `DataSource`-backed methods class + a
   `SamplerProvider` that delegates to `SamplerExtensionPoint`" is worth
   factoring out once a third sampler adopts this pattern. Not needed for two
   samplers — revisit if a third migration arrives.

--- a/roadrunner-app/jreleaser.yml
+++ b/roadrunner-app/jreleaser.yml
@@ -5,9 +5,10 @@ project:
     - Symentis.pl
   license: Apache-2.0
   inceptionYear: '2024'
-  java:
-    groupId: io.roadrunner
-    version: '25'
+  languages:
+    java:
+      groupId: io.roadrunner
+      version: '25'
 
 # The vX.Y.Z tag is already created and pushed by maven-release-plugin during
 # release:prepare; JReleaser only needs to publish a GitHub Release on top of
@@ -33,7 +34,7 @@ assemble:
   # Jlink assembler: self-contained runtime image (bundled JDK).
   # JARs in target/modules/ are used as module path; JReleaser auto-detects all modules.
   # No targetJdks -> JReleaser uses the current JDK (the one running the build).
-  # Note: jlink uses 'archiveFormat' (singular string).
+  # Note: jlink uses 'formats' (a list), same as javaArchive.
   jlink:
     roadrunner:
       active: ALWAYS
@@ -54,7 +55,8 @@ assemble:
       args:
         - --no-header-files
         - --no-man-pages
-      archiveFormat: ZIP
+      formats:
+        - ZIP
       imageName: 'roadrunner-app-{{projectVersion}}'
 
   # JavaArchive assembler: plain JAR distribution (requires user-supplied JDK).


### PR DESCRIPTION
## Summary

The build emits two JReleaser deprecation warnings:

```
🚨 project.java is deprecated since 1.16.0 and will be removed in 2.0.0. Use project.languages.java instead
🚨 jlink.archiveFormat is deprecated since 1.24.0 and will be removed in 2.0.0
```

This replaces both properties in `roadrunner-app/jreleaser.yml` with their non-deprecated equivalents (verified against the JReleaser 1.25.0 source, the version pinned in `roadrunner-app/pom.xml`):

- `project.java` → `project.languages.java`
- `jlink.archiveFormat: ZIP` → `jlink.formats: [ZIP]` (a list, mirroring the existing `javaArchive.formats`)

## Testing

- YAML validated and structure confirmed (no deprecated keys remain).
- Replacement property names confirmed against JReleaser 1.25.0 source (`Project.setJava` / `JlinkAssembler.setArchiveFormat` deprecation nags and their non-deprecated targets).
- `jreleaser:config` could not be run locally because this checkout is a git worktree, which JReleaser's JGit rejects during git HEAD resolution — unrelated to this change and does not occur in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)