### PR TITLE
Run dependency graph submission only on push to master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,5 +39,7 @@ jobs:
             token: ${{ secrets.CODECOV_TOKEN }}
 
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+      # PR builds run with a read-only GITHUB_TOKEN (enforced by GitHub for pull_request events), so this always fails with 403 there
       - name: Update dependency graph
+        if: github.event_name == 'push'
         uses: advanced-security/maven-dependency-submission-action@v5.0.0


### PR DESCRIPTION
## Summary
- The "Update dependency graph" step (`advanced-security/maven-dependency-submission-action`) always failed with `403 Resource not accessible by integration` on PR builds, since GitHub forces a read-only `GITHUB_TOKEN` on `pull_request` events regardless of the workflow's `permissions:` block.
- Skip that step unless the workflow was triggered by `push` (which is already scoped to `master`), so it only runs where it can actually succeed.

## Test plan
- [x] Confirmed root cause via failing PR #198 run (fork PR, `isCrossRepository: true`, 403 on dependency-graph snapshot POST)
- [ ] Confirm this PR's own build shows "Update dependency graph" skipped
- [ ] Confirm a subsequent push to master still runs and succeeds on that step

Fixes the failure seen in symentispl/roadrunner#198.